### PR TITLE
Fixed missing elevation fields in FITACF files when Radars do not hav…

### DIFF
--- a/pydarn/io/superdarn.py
+++ b/pydarn/io/superdarn.py
@@ -408,7 +408,8 @@ class DarnRead(DmapRead):
         # DarnUtilities for more information.
         file_struct_list = [superdarn_formats.Fitacf.types,
                             superdarn_formats.Fitacf.extra_fields,
-                            superdarn_formats.Fitacf.fitted_fields]
+                            superdarn_formats.Fitacf.fitted_fields,
+                            superdarn_formats.Fitacf.elevation_fields]
         self._read_darn_records(file_struct_list)
         return self._dmap_records
 
@@ -621,7 +622,8 @@ class DarnWrite(DmapWrite):
         # DarnUtilities for more information.
         file_struct_list = [superdarn_formats.Fitacf.types,
                             superdarn_formats.Fitacf.extra_fields,
-                            superdarn_formats.Fitacf.fitted_fields]
+                            superdarn_formats.Fitacf.fitted_fields,
+                            superdarn_formats.Fitacf.elevation_fields]
         self.superDARN_file_structure_to_bytes(file_struct_list)
         with open(self.filename, 'wb') as f:
             f.write(self.dmap_bytearr)

--- a/pydarn/io/superdarn_formats.py
+++ b/pydarn/io/superdarn_formats.py
@@ -157,7 +157,10 @@ class Fitacf():
         'w_s_e': 'f',
         'sd_l': 'f',
         'sd_s': 'f',
-        'sd_phi': 'f',
+        'sd_phi': 'f'}
+
+
+    elevation_fields = {
         'x_qflg': 'c',
         'x_gflg': 'c',
         'x_p_l': 'f',
@@ -177,7 +180,8 @@ class Fitacf():
         'elv_high': 'f',
         'x_sd_l': 'f',
         'x_sd_s': 'f',
-        'x_sd_phi': 'f'}
+        'x_sd_phi': 'f'
+    }
 
 
 class Grid():


### PR DESCRIPTION
Fixed the bug with `read_fitacf()` not being able to read in radar FITACF data that does not have elevation fields. 

This was a bug @aburrell found. 

Testing code:
```python
import pydarn

fitacf_file = ".20190203.0001.00.fhw.fitacf3"
fitacf_reader = pydarn.DarnRead(fitacf_file)
fitacf_dmap_data = fitacf_reader.read_fitacf()
```