### PR TITLE
changed default colormap and default parameter to velocity

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -48,14 +48,14 @@ class RTP():
                 "   - plot_summary()\n"
 
     @classmethod
-    def plot_range_time(cls, dmap_data: List[dict], parameter: str = 'p_l',
+    def plot_range_time(cls, dmap_data: List[dict], parameter: str = 'v',
                         beam_num: int = 0, channel: int = 'all', ax=None,
                         background: str = 'w', groundscatter: bool = False,
                         zmin: int = None, zmax: int = None,
                         start_time: datetime = None, end_time: datetime = None,
                         colorbar: plt.colorbar = None, ymax: int = None,
                         colorbar_label: str = '', norm=colors.Normalize,
-                        cmap: str = PyDARNColormaps.PYDARN, filter_settings: dict = {},
+                        cmap: str = PyDARNColormaps.PYDARN_VELOCITY, filter_settings: dict = {},
                         date_fmt: str = '%y/%m/%d\n %H:%M', **kwargs):
         """
         Plots a range-time parameter plot of the given
@@ -73,7 +73,7 @@ class RTP():
         dmap_data: List[dict]
         parameter: str
             key name indicating which parameter to plot.
-            Default: p_l (Signal to Noise)
+            Default: v (Velocity)
         beam_num : int
             The beam number of data to plot
             Default: 0
@@ -123,7 +123,7 @@ class RTP():
         cmap: str or matplotlib.cm
             matplotlib colour map
             https://matplotlib.org/tutorials/colors/colormaps.html
-            Default: PyDARNColormaps.PYDARN
+            Default: PyDARNColormaps.PYDARN_VELOCITY
             note: to reverse the color just add _r to the string name
         plot_filter: dict
             dictionary of the following keys for filtering data out:


### PR DESCRIPTION
As requested in #24 the new default parameter is `v` Velocity and the new default colormap is the PydDARN Velocity colormap. To keep with the majority of what users plot and with the velocity colormap convention. 

```
import pydarn
import matplotlib.pyplot as plt 

fitacf_file = "20180101.C0.cly.fitacf"
darn_read = pydarn.SDarnRead(fitacf_file)
fitacf_data = darn_read.read_fitacf()
pydarn.RTP.plot_range_time(fitacf_data, zmin=-600, zmax=600)
plt.show()
```
![RTI_velocity](https://user-images.githubusercontent.com/6520530/71014924-59bf4500-20b8-11ea-8494-d6bb8da1806a.png)

Granted this has one caveat with the other parameters:
![RTI_power](https://user-images.githubusercontent.com/6520530/71015077-a1de6780-20b8-11ea-9f64-fdb54d287861.png)

However, they can change colormaps flexibly:
```
import pydarn
import matplotlib.pyplot as plt 

fitacf_file = "20180101.C0.cly.fitacf"
darn_read = pydarn.SDarnRead(fitacf_file)
fitacf_data = darn_read.read_fitacf()
pydarn.RTP.plot_range_time(fitacf_data, parameter='p_l', cmap='plasma')
plt.show()
```
![RTI_plasma_SNR](https://user-images.githubusercontent.com/6520530/71015379-1ca78280-20b9-11ea-941a-8987a41ca8f0.png)


@billetd if you don't mind updating `plot_range_time` tutorials again to update with the new changes and mention that if users wish to use another colormap for parameters like `p_l` Signal to Noise with some suggestions. 