### PR TITLE
fixed a bug regarding getting max range gates from the data

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -217,8 +217,11 @@ class RTP():
         # TODO: implement variant other coordinate systems for the y-axis
         # y shape needs to be +1 longer as requirement of how pcolormesh
         # draws the pixels on the grid
-        y = np.arange(0, cls.dmap_data[0]['nrang']+1, 1)
-        y_max = cls.dmap_data[0]['nrang']
+
+        # because nrang can change based on mode we need to look
+        # for the largest value
+        y_max = max(record['nrang'] for record in cls.dmap_data)
+        y = np.arange(0, y_max+1, 1)
 
         # z: parameter data mapped into the color mesh
         z = np.zeros((1, y_max)) * np.nan


### PR DESCRIPTION
Was getting this error when concatenating 2-hour fitacf files and trying to plot the summary plots for each beam: 
 ```
Traceback (most recent call last):
  File "pydarn_summary_plots.py", line 60, in <module>
    plot_files(data, date, radar)
  File "pydarn_summary_plots.py", line 41, in plot_files
    pydarn.RTP.plot_summary(data, beam_num=beam)
  File "/usr/lib/python3.6/site-packages/pydarn-0.1.dev0-py3.6.egg/pydarn/plotting/rtp.py", line 892, in plot_summary
    background=background_color)
  File "/usr/lib/python3.6/site-packages/pydarn-0.1.dev0-py3.6.egg/pydarn/plotting/rtp.py", line 302, in plot_range_time
    dmap_record[parameter][j]
IndexError: index 75 is out of bounds for axis 0 with size 75
```
Realized the modes change the range gate values, so updated the code to search and find the max range gate used in the data set. 

This resolved the error. 

2019 11 27 RKN was one of the days that gave me this indexing error. 