### PR TITLE
fixed typo in RTPUnkownParameter

### DIFF
--- a/pydarn/exceptions/rtp_exceptions.py
+++ b/pydarn/exceptions/rtp_exceptions.py
@@ -78,13 +78,13 @@ class RTPZeroError(Exception):
         pydarn_log.error(self.message)
 
 
-class RTPUnknownParameter(Exception):
+class RTPUnknownParameterError(Exception):
     """
     Error raised when the parameter is not found in the data passed in
     """
     def __init__(self, parameter: str):
         self.parameter = parameter
-        self.message = "Error: The following parameter {parameter}"\
+        self.message = "The following parameter {parameter}"\
             " was not found in the"\
             " data set. Please make sure it is typed correctly or"\
             " you are using the correct data.".format(parameter=self.parameter)

--- a/pydarn/exceptions/rtp_exceptions.py
+++ b/pydarn/exceptions/rtp_exceptions.py
@@ -84,8 +84,9 @@ class RTPUnknownParameter(Exception):
     """
     def __init__(self, parameter: str):
         self.parameter = parameter
-        self.message = "Error: The following parameter was not found in the"\
+        self.message = "Error: The following parameter {parameter}"\
+            " was not found in the"\
             " data set. Please make sure it is typed correctly or"\
-            " you are using the correct data."
+            " you are using the correct data.".format(parameter=self.parameter)
         super().__init__(self.message)
         pydarn_log.error(self.message)

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -207,7 +207,7 @@ class RTP():
                isinstance(dmap_data[index_first_match][parameter], DmapScalar):
                 dmap_data = dmap2dict(dmap_data)
         except StopIteration:
-            raise rtp_exceptions.RTPUnknownParameter(parameter)
+            raise rtp_exceptions.RTPUnknownParameterError(parameter)
         cls.dmap_data = dmap_data
         cls.__check_data_type(parameter, 'array', index_first_match)
         start_time, end_time = cls.__determine_start_end_time(start_time,
@@ -467,7 +467,7 @@ class RTP():
                isinstance(dmap_data[index_first_match][parameter], DmapScalar):
                 dmap_data = dmap2dict(dmap_data)
         except StopIteration:
-            raise rtp_exceptions.RTPUnknownParameter(parameter)
+            raise rtp_exceptions.RTPUnknownParameterError(parameter)
 
         cls.dmap_data = dmap_data
         cls.__check_data_type(parameter, 'scalar', index_first_match)


### PR DESCRIPTION
Before the `RTPUnkownParameter` would print:
```
pydarn.exceptions.rtp_exceptions.RTPUnknownParameter: Error: The following parameter was not found in the data set. Please make sure it is typed correctly or you are using the correct data.
```

Now it prints `RTPUnkownParameterError`:
```
pydarn.exceptions.rtp_exceptions.RTPUnknownParameterError: The following parameter p_l was not found in the data set. Please make sure it is typed correctly or you are using the correct data.
```

This error is thrown while generating summary plots for 20180903 unw due to the whole data set being partial records. 