### PR TITLE
Deprecation of IO package

### DIFF
--- a/pydarn/io/borealis/borealis.py
+++ b/pydarn/io/borealis/borealis.py
@@ -122,6 +122,12 @@ class BorealisRead():
         BorealisStructureError
             Unknown structure type.
         """
+        warnings.simplefilter('once', DeprecationWarning)
+        warnings.warn("BorelaisRead method will be removed from pyDARN v 1.2,"
+                      " please use pyDARNio: "
+                      "https://github.com/SuperDARN/pyDARNio",
+                      DeprecationWarning)
+
         self.filename = filename
 
         if borealis_filetype not in ['bfiq', 'antennas_iq', 'rawacf', 'rawrf']:
@@ -342,6 +348,12 @@ class BorealisWrite():
         hdf5_compression: str
             A kwarg key name, giving a string representing compression type.
         """
+        warnings.simplefilter('once', DeprecationWarning)
+        warnings.warn("BorelaisWrite method will be removed from pyDARN v 1.2,"
+                      " please use pyDARNio: "
+                      "https://github.com/SuperDARN/pyDARNio",
+                      DeprecationWarning)
+
         self.filename = filename
         self.data = borealis_data
         self.borealis_filetype = borealis_filetype

--- a/pydarn/io/borealis/borealis.py
+++ b/pydarn/io/borealis/borealis.py
@@ -38,6 +38,7 @@ filetypes, see: https://borealis.readthedocs.io/en/latest/
 """
 
 import logging
+import warnings
 
 from collections import OrderedDict
 from typing import Union
@@ -123,7 +124,7 @@ class BorealisRead():
             Unknown structure type.
         """
         warnings.simplefilter('once', PendingDeprecationWarning)
-        warnings.warn("BorelaisRead method will be removed from pyDARN v 1.2,"
+        warnings.warn("BorealisRead method will be removed from pyDARN v 1.2,"
                       " please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
                       PendingDeprecationWarning)
@@ -349,7 +350,7 @@ class BorealisWrite():
             A kwarg key name, giving a string representing compression type.
         """
         warnings.simplefilter('once', PendingDeprecationWarning)
-        warnings.warn("BorelaisWrite method will be removed from pyDARN v 1.2,"
+        warnings.warn("BorealisWrite method will be removed from pyDARN v 1.2,"
                       " please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
                       PendingDeprecationWarning)

--- a/pydarn/io/borealis/borealis.py
+++ b/pydarn/io/borealis/borealis.py
@@ -122,11 +122,11 @@ class BorealisRead():
         BorealisStructureError
             Unknown structure type.
         """
-        warnings.simplefilter('once', DeprecationWarning)
+        warnings.simplefilter('once', PendingDeprecationWarning)
         warnings.warn("BorelaisRead method will be removed from pyDARN v 1.2,"
                       " please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
-                      DeprecationWarning)
+                      PendingDeprecationWarning)
 
         self.filename = filename
 
@@ -348,11 +348,11 @@ class BorealisWrite():
         hdf5_compression: str
             A kwarg key name, giving a string representing compression type.
         """
-        warnings.simplefilter('once', DeprecationWarning)
+        warnings.simplefilter('once', PendingDeprecationWarning)
         warnings.warn("BorelaisWrite method will be removed from pyDARN v 1.2,"
                       " please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
-                      DeprecationWarning)
+                      PendingDeprecationWarning)
 
         self.filename = filename
         self.data = borealis_data

--- a/pydarn/io/borealis/borealis_array.py
+++ b/pydarn/io/borealis/borealis_array.py
@@ -39,6 +39,7 @@ files, see: https://borealis.readthedocs.io/en/latest/
 """
 import deepdish as dd
 import logging
+import warnings
 
 from typing import List
 
@@ -106,7 +107,7 @@ class BorealisArrayRead():
             Borealis software version format does not exist in pydarn
         """
         warnings.simplefilter('once', PendingDeprecationWarning)
-        warnings.warn("BorelaisArrayRead method will be removed from"
+        warnings.warn("BorealisArrayRead method will be removed from"
                       " pyDARN v 1.2, please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
                       PendingDeprecationWarning)
@@ -357,7 +358,7 @@ class BorealisArrayWrite():
             Borealis software version format does not exist in pydarn
         """
         warnings.simplefilter('once', PendingDeprecationWarning)
-        warnings.warn("BorelaisArrayWrite method will be removed from"
+        warnings.warn("BorealisArrayWrite method will be removed from"
                       " pyDARN v 1.2, please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
                       PendingDeprecationWarning)

--- a/pydarn/io/borealis/borealis_array.py
+++ b/pydarn/io/borealis/borealis_array.py
@@ -105,6 +105,12 @@ class BorealisArrayRead():
         BorealisVersionError
             Borealis software version format does not exist in pydarn
         """
+        warnings.simplefilter('once', DeprecationWarning)
+        warnings.warn("BorelaisArrayRead method will be removed from"
+                      " pyDARN v 1.2, please use pyDARNio: "
+                      "https://github.com/SuperDARN/pyDARNio",
+                      DeprecationWarning)
+
         self.filename = filename
 
         if borealis_filetype not in ['bfiq', 'antennas_iq', 'rawacf', 'rawrf']:
@@ -350,6 +356,12 @@ class BorealisArrayWrite():
         BorealisVersionError
             Borealis software version format does not exist in pydarn
         """
+        warnings.simplefilter('once', DeprecationWarning)
+        warnings.warn("BorelaisArrayWrite method will be removed from"
+                      " pyDARN v 1.2, please use pyDARNio: "
+                      "https://github.com/SuperDARN/pyDARNio",
+                      DeprecationWarning)
+
         self.filename = filename
         self._arrays = borealis_arrays
         if borealis_filetype not in ['bfiq', 'antennas_iq', 'rawacf', 'rawrf']:

--- a/pydarn/io/borealis/borealis_array.py
+++ b/pydarn/io/borealis/borealis_array.py
@@ -105,11 +105,11 @@ class BorealisArrayRead():
         BorealisVersionError
             Borealis software version format does not exist in pydarn
         """
-        warnings.simplefilter('once', DeprecationWarning)
+        warnings.simplefilter('once', PendingDeprecationWarning)
         warnings.warn("BorelaisArrayRead method will be removed from"
                       " pyDARN v 1.2, please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
-                      DeprecationWarning)
+                      PendingDeprecationWarning)
 
         self.filename = filename
 
@@ -356,11 +356,11 @@ class BorealisArrayWrite():
         BorealisVersionError
             Borealis software version format does not exist in pydarn
         """
-        warnings.simplefilter('once', DeprecationWarning)
+        warnings.simplefilter('once', PendingDeprecationWarning)
         warnings.warn("BorelaisArrayWrite method will be removed from"
                       " pyDARN v 1.2, please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
-                      DeprecationWarning)
+                      PendingDeprecationWarning)
 
         self.filename = filename
         self._arrays = borealis_arrays

--- a/pydarn/io/borealis/borealis_convert.py
+++ b/pydarn/io/borealis/borealis_convert.py
@@ -196,11 +196,11 @@ class BorealisConvert(BorealisRead):
         BorealisConversionTypesError
         ConvertFileOverWriteError
         """
-        warnings.simplefilter('once', DeprecationWarning)
+        warnings.simplefilter('once', PendingDeprecationWarning)
         warnings.warn("BorelaisConvert method will be removed from "
                       "pyDARN v 1.2, please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
-                      DeprecationWarning)
+                      PendingDeprecationWarning)
 
         super(BorealisConvert, self).__init__(borealis_filename,
                                               borealis_filetype,

--- a/pydarn/io/borealis/borealis_convert.py
+++ b/pydarn/io/borealis/borealis_convert.py
@@ -43,6 +43,7 @@ Update noise values in SDarn fields when these can be calculated.
 import logging
 import math
 import numpy as np
+import warnings
 
 from datetime import datetime
 from typing import Union
@@ -197,7 +198,7 @@ class BorealisConvert(BorealisRead):
         ConvertFileOverWriteError
         """
         warnings.simplefilter('once', PendingDeprecationWarning)
-        warnings.warn("BorelaisConvert method will be removed from "
+        warnings.warn("BorealisConvert method will be removed from "
                       "pyDARN v 1.2, please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
                       PendingDeprecationWarning)

--- a/pydarn/io/borealis/borealis_convert.py
+++ b/pydarn/io/borealis/borealis_convert.py
@@ -196,6 +196,11 @@ class BorealisConvert(BorealisRead):
         BorealisConversionTypesError
         ConvertFileOverWriteError
         """
+        warnings.simplefilter('once', DeprecationWarning)
+        warnings.warn("BorelaisConvert method will be removed from "
+                      "pyDARN v 1.2, please use pyDARNio: "
+                      "https://github.com/SuperDARN/pyDARNio",
+                      DeprecationWarning)
 
         super(BorealisConvert, self).__init__(borealis_filename,
                                               borealis_filetype,
@@ -450,14 +455,14 @@ class BorealisConvert(BorealisRead):
 
         Notes
         -----
-        SuperDARN RFC 0027 specifies that the dimensions of the data in 
+        SuperDARN RFC 0027 specifies that the dimensions of the data in
         iqdat should be by number of sequences, number of arrays, number
         of samples, 2 (i+q). There is some history where the dimensions were
-        instead sequences, samples, arrays, 2(i+q). We have chosen to 
+        instead sequences, samples, arrays, 2(i+q). We have chosen to
         use the former, as it is consistent with the rest of SuperDARN Canada
         radars at this time and is as specified in the document. This means
         that you may need to use make_raw with the -d option in RST if you
-        wish to process the resulting iqdat into rawacf. 
+        wish to process the resulting iqdat into rawacf.
 
         Returns
         -------

--- a/pydarn/io/borealis/borealis_site.py
+++ b/pydarn/io/borealis/borealis_site.py
@@ -111,6 +111,12 @@ class BorealisSiteRead():
         BorealisVersionError
             Borealis software version format does not exist in pydarn
         """
+        warnings.simplefilter('once', DeprecationWarning)
+        warnings.warn("BorelaisSiteRead method will be removed from pyDARN v 1.2,"
+                      " please use pyDARNio: "
+                      "https://github.com/SuperDARN/pyDARNio",
+                      DeprecationWarning)
+
         self.filename = filename
         if borealis_filetype not in ['bfiq', 'antennas_iq', 'rawacf', 'rawrf']:
             raise borealis_exceptions.BorealisFileTypeError(
@@ -362,6 +368,12 @@ class BorealisSiteWrite():
         BorealisVersionError
             Borealis software version format does not exist in pydarn
         """
+        warnings.simplefilter('once', DeprecationWarning)
+        warnings.warn("BorelaisSiteWrite method will be removed from pyDARN v 1.2,"
+                      " please use pyDARNio: "
+                      "https://github.com/SuperDARN/pyDARNio",
+                      DeprecationWarning)
+
         self._records = borealis_records
         if borealis_filetype not in ['bfiq', 'antennas_iq', 'rawacf', 'rawrf']:
             raise borealis_exceptions.BorealisFileTypeError(

--- a/pydarn/io/borealis/borealis_site.py
+++ b/pydarn/io/borealis/borealis_site.py
@@ -112,7 +112,7 @@ class BorealisSiteRead():
             Borealis software version format does not exist in pydarn
         """
         warnings.simplefilter('once', PendingDeprecationWarning)
-        warnings.warn("BorelaisSiteRead method will be removed from pyDARN v 1.2,"
+        warnings.warn("BorealisSiteRead method will be removed from pyDARN v 1.2,"
                       " please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
                       PendingDeprecationWarning)
@@ -369,7 +369,7 @@ class BorealisSiteWrite():
             Borealis software version format does not exist in pydarn
         """
         warnings.simplefilter('once', PendingDeprecationWarning)
-        warnings.warn("BorelaisSiteWrite method will be removed from pyDARN v 1.2,"
+        warnings.warn("BorealisSiteWrite method will be removed from pyDARN v 1.2,"
                       " please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
                       PendingDeprecationWarning)

--- a/pydarn/io/borealis/borealis_site.py
+++ b/pydarn/io/borealis/borealis_site.py
@@ -111,11 +111,11 @@ class BorealisSiteRead():
         BorealisVersionError
             Borealis software version format does not exist in pydarn
         """
-        warnings.simplefilter('once', DeprecationWarning)
+        warnings.simplefilter('once', PendingDeprecationWarning)
         warnings.warn("BorelaisSiteRead method will be removed from pyDARN v 1.2,"
                       " please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
-                      DeprecationWarning)
+                      PendingDeprecationWarning)
 
         self.filename = filename
         if borealis_filetype not in ['bfiq', 'antennas_iq', 'rawacf', 'rawrf']:
@@ -368,11 +368,11 @@ class BorealisSiteWrite():
         BorealisVersionError
             Borealis software version format does not exist in pydarn
         """
-        warnings.simplefilter('once', DeprecationWarning)
+        warnings.simplefilter('once', PendingDeprecationWarning)
         warnings.warn("BorelaisSiteWrite method will be removed from pyDARN v 1.2,"
                       " please use pyDARNio: "
                       "https://github.com/SuperDARN/pyDARNio",
-                      DeprecationWarning)
+                      PendingDeprecationWarning)
 
         self._records = borealis_records
         if borealis_filetype not in ['bfiq', 'antennas_iq', 'rawacf', 'rawrf']:

--- a/pydarn/io/dmap.py
+++ b/pydarn/io/dmap.py
@@ -148,8 +148,10 @@ class DmapRead():
         --------
         read_records : to obtain dmap_records
         """
-        warnings.simplefilter('once', DeprecationWarning)
-        warnings.warn("DampRead method will be removed from pyDARN v 1.2, please use pyDARNio: https://github.com/SuperDARN/pyDARNio", DeprecationWarning)
+        warnings.warn("DampRead method will be removed from pyDARN v 1.2,"
+                      " please use pyDARNio:"
+                      " https://github.com/SuperDARN/pyDARNio",
+                      PendingDeprecationWarning)
         self.rec_num = 0
         self.cursor = 0  # Current position in bytes
         self.dmap_end_bytes = 0  # total number of bytes in the dmap_file
@@ -888,8 +890,10 @@ class DmapWrite(object):
         DmapTypeError
         FilenameRequiredError
         """
-        warnings.simplefilter('once', DeprecationWarning)
-        warnings.warn("DampWrite method will be removed from pyDARN v 1.2, please use pyDARNio: https://github.com/SuperDARN/pyDARNio", DeprecationWarning)
+        warnings.warn("DampWrite method will be removed from pyDARN v 1.2,"
+                      " please use pyDARNio:"
+                      " https://github.com/SuperDARN/pyDARNio",
+                      PendingDeprecationWarning)
 
         self.filename = filename
         self.rec_num = 0

--- a/pydarn/io/dmap.py
+++ b/pydarn/io/dmap.py
@@ -37,6 +37,7 @@ import logging
 import numpy as np
 import os
 import struct
+import warnings
 
 from typing import List, Union
 
@@ -147,6 +148,8 @@ class DmapRead():
         --------
         read_records : to obtain dmap_records
         """
+        warnings.simplefilter('once', DeprecationWarning)
+        warnings.warn("DampRead method will be removed from pyDARN v 1.2, please use pyDARNio: https://github.com/SuperDARN/pyDARNio", DeprecationWarning)
         self.rec_num = 0
         self.cursor = 0  # Current position in bytes
         self.dmap_end_bytes = 0  # total number of bytes in the dmap_file
@@ -885,6 +888,9 @@ class DmapWrite(object):
         DmapTypeError
         FilenameRequiredError
         """
+        warnings.simplefilter('once', DeprecationWarning)
+        warnings.warn("DampWrite method will be removed from pyDARN v 1.2, please use pyDARNio: https://github.com/SuperDARN/pyDARNio", DeprecationWarning)
+
         self.filename = filename
         self.rec_num = 0
 

--- a/pydarn/io/dmap.py
+++ b/pydarn/io/dmap.py
@@ -148,7 +148,7 @@ class DmapRead():
         --------
         read_records : to obtain dmap_records
         """
-        warnings.warn("DampRead method will be removed from pyDARN v 1.2,"
+        warnings.warn("DmapRead method will be removed from pyDARN v 1.2,"
                       " please use pyDARNio:"
                       " https://github.com/SuperDARN/pyDARNio",
                       PendingDeprecationWarning)
@@ -890,7 +890,7 @@ class DmapWrite(object):
         DmapTypeError
         FilenameRequiredError
         """
-        warnings.warn("DampWrite method will be removed from pyDARN v 1.2,"
+        warnings.warn("DmapWrite method will be removed from pyDARN v 1.2,"
                       " please use pyDARNio:"
                       " https://github.com/SuperDARN/pyDARNio",
                       PendingDeprecationWarning)

--- a/pydarn/io/superdarn.py
+++ b/pydarn/io/superdarn.py
@@ -36,6 +36,7 @@ Notes
 DmapRead and DmapWrite are inherited by SDarnRead and SDarnWrite
 """
 import logging
+import warnings
 
 from typing import Union, List
 
@@ -310,6 +311,9 @@ class SDarnRead(DmapRead):
         --------
         DmapRead : for inheritance information
         """
+        warnings.simplefilter('once', DeprecationWarning)
+        warnings.warn("SDarnRead method will be removed from pyDARN v 1.2, please use pyDARNio: https://github.com/SuperDARN/pyDARNio", DeprecationWarning)
+
         DmapRead.__init__(self, filename, stream)
 
     # helper function that could be used parallelization
@@ -550,6 +554,9 @@ class SDarnWrite(DmapWrite):
         filename : str
             Name of the file the user wants to write to
         """
+        warnings.simplefilter('once', DeprecationWarning)
+        warnings.warn("SDarnWrite method will be removed from pyDARN v 1.2, please use pyDARNio: https://github.com/SuperDARN/pyDARNio", DeprecationWarning)
+
         DmapWrite.__init__(self, dmap_records, filename)
 
         # WARNING: This check will be removed when real-time is implemented to

--- a/pydarn/io/superdarn.py
+++ b/pydarn/io/superdarn.py
@@ -561,7 +561,7 @@ class SDarnWrite(DmapWrite):
         warnings.warn("SDarnWrite method will be removed from pyDARN v 1.2,"
                       " please use pyDARNio:"
                       "https://github.com/SuperDARN/pyDARNio",
-                      DeprecationWarning)
+                      PendingDeprecationWarning)
 
         DmapWrite.__init__(self, dmap_records, filename)
 

--- a/pydarn/io/superdarn.py
+++ b/pydarn/io/superdarn.py
@@ -311,8 +311,12 @@ class SDarnRead(DmapRead):
         --------
         DmapRead : for inheritance information
         """
-        warnings.simplefilter('once', DeprecationWarning)
-        warnings.warn("SDarnRead method will be removed from pyDARN v 1.2, please use pyDARNio: https://github.com/SuperDARN/pyDARNio", DeprecationWarning)
+
+        warnings.simplefilter('once', PendingDeprecationWarning)
+        warnings.warn("SDarnRead method will be removed from pyDARN v 1.2,"
+                      " please use pyDARNio: "
+                      "https://github.com/SuperDARN/pyDARNio",
+                      PendingDeprecationWarning)
 
         DmapRead.__init__(self, filename, stream)
 
@@ -554,8 +558,10 @@ class SDarnWrite(DmapWrite):
         filename : str
             Name of the file the user wants to write to
         """
-        warnings.simplefilter('once', DeprecationWarning)
-        warnings.warn("SDarnWrite method will be removed from pyDARN v 1.2, please use pyDARNio: https://github.com/SuperDARN/pyDARNio", DeprecationWarning)
+        warnings.warn("SDarnWrite method will be removed from pyDARN v 1.2,"
+                      " please use pyDARNio:"
+                      "https://github.com/SuperDARN/pyDARNio",
+                      DeprecationWarning)
 
         DmapWrite.__init__(self, dmap_records, filename)
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     url='https://github.com/SuperDARN/pydarn.git',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'],
     python_requires='>=3.6',


### PR DESCRIPTION
## Scope
Package removed: pydarn/io
New location: [pyDARNio](https://github.com/superdarn/pyDARNio)

### Reason
As discussed in the pyDARN dev meeting we are moving the pyDARN io out as it is it's own package and doesn't meet pyDARN's scope. 

### Test
```python
import pydarn
import matplotlib.pyplot as plt 
from datetime import datetime

reader = pydarn.SDarnRead("20181220.1201.00.cly.rawacf")
data = reader.read_rawacf()
pydarn.ACF.plot_acfs(data, beam_num=5, gate_num=9,
                start_time=datetime(2018, 12, 20, 12, 4)) 
plt.show()
```

**output**

```bash
/usr/local/lib/python3.6/dist-packages/pydarn-1.0.0-py3.6.egg/pydarn/io/superdarn.py: 319: PendingDeprecationWarning: SDarnRead method will be removed from pyDARN v 1.2, please use pyDARNio: https://github.com/SuperDARN/pyDARNio
/usr/local/lib/python3.6/dist-packages/pydarn-1.0.0-py3.6.egg/pydarn/io/dmap.py: 154: PendingDeprecationWarning: DampRead method will be removed from pyDARN v 1.2, please use pyDARNio: https://github.com/SuperDARN/pyDARNio
```
