### PR TITLE
NEW Feature: Slant Range

### DIFF
--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -31,6 +31,7 @@ from .io import superdarn_formats
 # importing utils
 from .utils.conversions import dict2dmap
 from .utils.conversions import dmap2dict
+from .utils.conversions import gate2slant
 from .utils.plotting import check_data_type
 from .utils.plotting import time2datetime
 from .utils.superdarn_radars import SuperDARNRadars

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -102,7 +102,7 @@ class RTP():
         ymax: int
             Sets the maximum y value
             Default: None, uses 'nrang' from data
-        slant: boolen
+        slant: boolean
             set the y-axis to slant range (km)
             if false will show gate numbers.
             Default: True

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -642,7 +642,7 @@ class RTP():
     @classmethod
     def plot_summary(cls, dmap_data: List[dict], beam_num: int = 0,
                      groundscatter: bool = True, channel: int = 'all',
-                     slant=True, figsize: tuple = (11, 8.5),
+                     slant: bool = True, figsize: tuple = (11, 8.5),
                      watermark: bool = True, boundary: dict = {},
                      background_color: str = 'w', cmaps: dict = {},
                      lines: dict = {}, plot_elv: bool = True, title=None):
@@ -926,6 +926,10 @@ class RTP():
             else:
                 # Current standard is to only have groundscatter
                 # on the velocity plot. This may change in the future.
+                if slant:
+                    ymax = 3517.5
+                else:
+                    ymax = 75
                 if groundscatter and axes_parameters[i] == 'v':
                     grndflg = True
                 else:
@@ -942,7 +946,7 @@ class RTP():
                                         cmap=cmap[axes_parameters[i]],
                                         zmin=boundary_ranges[axes_parameters[i]][0],
                                         zmax=boundary_ranges[axes_parameters[i]][1],
-                                        ymax=3517.5,
+                                        ymax=ymax,
                                         background=background_color)
                 # Overwriting velocity ticks to get a better pleasing
                 # look on the colorbar

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -55,8 +55,8 @@ class RTP():
                         zmin: int = None, zmax: int = None,
                         start_time: datetime = None, end_time: datetime = None,
                         colorbar: plt.colorbar = None, ymax: int = None,
-                        slant = True,
-                        colorbar_label: str = '', norm=colors.Normalize,
+                        slant: bool = True, colorbar_label: str = '',
+                        norm=colors.Normalize,
                         cmap: str = PyDARNColormaps.PYDARN_VELOCITY,
                         filter_settings: dict = {},
                         date_fmt: str = '%y/%m/%d\n %H:%M', **kwargs):
@@ -365,7 +365,11 @@ class RTP():
         if ymax is None:
                 ymax = max(y)
         ax.set_ylim(0, ymax)
-        ax.yaxis.set_ticks(np.arange(0, ymax+1, (ymax)/5))
+
+        if slant:
+            ax.yaxis.set_ticks(np.arange(0, ymax+1), 200)
+        else:
+            ax.yaxis.set_ticks(np.arange(0, ymax+1, (ymax)/5))
 
         # SuperDARN file typically are in 2hr or 24 hr files
         # to make the minute ticks sensible, the time length is detected

--- a/pydarn/utils/conversions.py
+++ b/pydarn/utils/conversions.py
@@ -151,16 +151,18 @@ def gate2slant(record, nrang, center=True):
     """
 
     # lag to the first range gate in microseconds
-    # TODO: with 2.0 and 0.3 what do these values mean?
-    lag_first = record['frang'] * 2.0 / 0.3
+    # 0.3 - speed of light (km/us)
+    # 2 - two times for there and back
+    speed_of_light = 0.3 # TODO: should this be more accurate?
+    distance_factor = 2.0
+    lag_first = record['frang'] * distance_factor / speed_of_light
 
     # sample separation in microseconds
-    sample_sep = record['rsep'] * 2.0 / 0.3
-
+    sample_sep = record['rsep'] * distance_factor / speed_of_light
     # Range offset
     # If center is true, calculate at the center
     if center:
-        # TODO: why -0.5? what does this value mean?
+        # 0.5 off set to the centre of the range gate instead of edge
         range_offset = -0.5 * record['rsep']
     else:
         range_offset = 0.0
@@ -169,5 +171,5 @@ def gate2slant(record, nrang, center=True):
     slant_ranges = np.zeros(nrang+1)
     for gate in range(nrang+1):
         slant_ranges[gate] = (lag_first - record['rxrise'] +
-                              gate * sample_sep) * 0.3 / 2.0 + range_offset
+                              gate * sample_sep) * distance_factor / speed_of_light + range_offset
     return slant_ranges

--- a/pydarn/utils/conversions.py
+++ b/pydarn/utils/conversions.py
@@ -153,7 +153,7 @@ def gate2slant(record, nrang, center=True):
     # lag to the first range gate in microseconds
     # 0.3 - speed of light (km/us)
     # 2 - two times for there and back
-    speed_of_light = 0.3 # TODO: should this be more accurate?
+    speed_of_light = 0.3  # TODO: should this be more accurate?
     distance_factor = 2.0
     lag_first = record['frang'] * distance_factor / speed_of_light
 
@@ -171,5 +171,6 @@ def gate2slant(record, nrang, center=True):
     slant_ranges = np.zeros(nrang+1)
     for gate in range(nrang+1):
         slant_ranges[gate] = (lag_first - record['rxrise'] +
-                              gate * sample_sep) * distance_factor / speed_of_light + range_offset
+                              gate * sample_sep) * speed_of_light /\
+                distance_factor + range_offset
     return slant_ranges

--- a/pydarn/utils/conversions.py
+++ b/pydarn/utils/conversions.py
@@ -128,3 +128,46 @@ def dmap2dict(dmap_records: List[dict]) -> List[dict]:
                      for field, data in dmap_record.items()}
         dmap_list.append(OrderedDict(dmap_dict))
     return dmap_list
+
+
+def gate2slant(record, nrang, center=True):
+    """
+    Calculate the slant range (km) for each range gate for SuperDARN data
+
+    Parameters
+    ----------
+        record: dict
+            dictionary of superdarn data records
+        nrang: int
+            max number of range gates in the list of records
+        center: boolean
+            Calculate the slant range in the center of range gate
+            or edge
+
+    Returns
+    -------
+        slant_ranges : np.array
+            returns an array of slant ranges for the radar
+    """
+
+    # lag to the first range gate in microseconds
+    # TODO: with 2.0 and 0.3 what do these values mean?
+    lag_first = record['frang'] * 2.0 / 0.3
+
+    # sample separation in microseconds
+    sample_sep = record['rsep'] * 2.0 / 0.3
+
+    # Range offset
+    # If center is true, calculate at the center
+    if center:
+        # TODO: why -0.5? what does this value mean?
+        range_offset = -0.5 * record['rsep']
+    else:
+        range_offset = 0.0
+
+    # Now calculate slant range in km
+    slant_ranges = np.zeros(nrang+1)
+    for gate in range(nrang+1):
+        slant_ranges[gate] = (lag_first - record['rxrise'] +
+                              gate * sample_sep) * 0.3 / 2.0 + range_offset
+    return slant_ranges


### PR DESCRIPTION
# Scope
Feature: `gate2slant`
module: *conversions.py*
package: *utils*

## Description
This new feature converts range gates to slant ranges (km) brought up by trying to overlay PFISR (Poker Flat Incoherent Scatter Radar) data with KOD SuperDARN data. 

I based the code off of [DaVitpy slant range calculation](https://github.com/vtsuperdarn/davitpy/blob/f2c11e34f781ba5fd027b5ce789d39ff1f4f86f1/davitpy/pydarn/radar/radFov.py)

## Test 
```python
import matplotlib.pyplot as plt 
import pydarn
import logging

#Load in dmap file
file = "20180220.C0.rkn.fitacf"
SDarn_read = pydarn.SDarnRead(file)
fitacf_data = SDarn_read.read_fitacf()
#Plot FOV and show
a = pydarn.RTP.plot_range_time(fitacf_data, beam_num=5)
#a = pydarn.RTP.plot_summary(fitacf_data, beam_num=5)
plt.show()
```
If you plot a Range-time Parameter plot you get:
![slant1](https://user-images.githubusercontent.com/6520530/87721514-c8aa6c80-c773-11ea-9321-956e77730d3d.png)


If you plot a Summar plot you get:
![slant2](https://user-images.githubusercontent.com/6520530/87721463-b16b7f00-c773-11ea-8925-80b1d827ebc5.png)

## HELP!
- [ ] Validate the slant ranges are correct
- [ ] gate range 75 ~ 3500 km for summary plot purposes 
- [ ] Does 100 minor ticks make sense for slant ranges?
- [ ] should we keep 0 km as the axis point?

## TODO
- [ ] Documentation
- [ ] Unit Tests 
