### PR TITLE
Scan locating and labelling

### DIFF
--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -37,6 +37,7 @@ from .utils.superdarn_radars import SuperDARNRadars
 from .utils.superdarn_cpid import SuperDARNCpids
 from .utils.superdarn_radars import Hemisphere
 from .utils.superdarn_radars import read_hdw_file
+from .utils.scan import build_scan
 
 # Importing pydarn dmap classes
 from .io.dmap import DmapRead

--- a/pydarn/utils/scan.py
+++ b/pydarn/utils/scan.py
@@ -17,6 +17,11 @@ def build_scan(dmap_data: List[dict]):
     ----------
     dmap_data: List(dict)
         list of records (dictionaries) representing dmap data
+    Returns 
+    ----------
+    beam_scan: List
+        list of size equal to number of records in dmap_data, with scan number
+    for each record
     """ 
     # Set up scans for easy locating
     # Makes a list of size (number of records), with the scan number for each

--- a/pydarn/utils/scan.py
+++ b/pydarn/utils/scan.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2020 SuperDARN Canada, Universtiy of Saskatchewan
 # Author(s): Daniel Billett
 """
-This module is is used for sorting a given dmap_data list of dictionaries
+This module is used for sorting a given dmap_data list of dictionaries
 into scans
 """
 

--- a/pydarn/utils/scan.py
+++ b/pydarn/utils/scan.py
@@ -26,13 +26,13 @@ def build_scan(dmap_data: List[dict]):
     # Set up scans for easy locating
     # Makes a list of size (number of records), with the scan number for each
     scan_mark = [sub['scan'] for sub in dmap_data]
-    no_scans = 0
+    current_scan = 0
     beam_scan = np.zeros((len(dmap_data)))
     for beam in range(len(dmap_data)):
-        if abs(scan_mark[beam]) == 1:
-            no_scans += 1
-            beam_scan[beam] = no_scans
+        if abs(scan_mark[beam]) == 1: #Absoloute value used due to some scan flags set as "-1"
+            current_scan += 1
+            beam_scan[beam] = current_scan
         if scan_mark[beam] == 0:
-            beam_scan[beam] = no_scans
+            beam_scan[beam] = current_scan
     
     return beam_scan

--- a/pydarn/utils/scan.py
+++ b/pydarn/utils/scan.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2020 SuperDARN Canada, Universtiy of Saskatchewan
+# Author(s): Daniel Billett
+"""
+This module is is used for sorting a given dmap_data list of dictionaries
+into scans
+"""
+
+import numpy as np
+from typing import List
+
+def build_scan(dmap_data: List[dict]):
+    """
+    Returns list of size equal tonumber of records in dmap_data, with scan number
+    for each record
+
+    Parameters
+    ----------
+    dmap_data: List(dict)
+        list of records (dictionaries) representing dmap data
+    """ 
+    # Setup scans for easy locating
+    # Makes a list of size (number of records), with the scan number for each
+    scan_mark = [sub['scan'] for sub in dmap_data]
+    no_scans = 0
+    beam_scan = np.zeros((len(dmap_data)))
+    for beam in range(len(dmap_data)):
+        if abs(scan_mark[beam]) == 1:
+            no_scans += 1
+            beam_scan[beam] = no_scans
+        if scan_mark[beam] == 0:
+            beam_scan[beam] = no_scans
+    no_scans += 1
+    
+    return beam_scan

--- a/pydarn/utils/scan.py
+++ b/pydarn/utils/scan.py
@@ -29,6 +29,5 @@ def build_scan(dmap_data: List[dict]):
             beam_scan[beam] = no_scans
         if scan_mark[beam] == 0:
             beam_scan[beam] = no_scans
-    no_scans += 1
     
     return beam_scan

--- a/pydarn/utils/scan.py
+++ b/pydarn/utils/scan.py
@@ -10,7 +10,7 @@ from typing import List
 
 def build_scan(dmap_data: List[dict]):
     """
-    Returns list of size equal tonumber of records in dmap_data, with scan number
+    Returns list of size equal to number of records in dmap_data, with scan number
     for each record
 
     Parameters

--- a/pydarn/utils/scan.py
+++ b/pydarn/utils/scan.py
@@ -18,7 +18,7 @@ def build_scan(dmap_data: List[dict]):
     dmap_data: List(dict)
         list of records (dictionaries) representing dmap data
     """ 
-    # Setup scans for easy locating
+    # Set up scans for easy locating
     # Makes a list of size (number of records), with the scan number for each
     scan_mark = [sub['scan'] for sub in dmap_data]
     no_scans = 0


### PR DESCRIPTION
# New Feature 
**Scan formation**

**module:** *scan.py*

**package:** *pydarn/utils*

## Scope
This PR adds rudimentary functionality to seperate a dmap_data list of libraries into scans, according to the scan flag specified within the records.

`build_scan` simply returns a 1D list with length equal to the number of dmap records, with an integer number indicating which scan each record is a part of. Initially this will be used for fan plots when merged, and so this functionality will be removed from PR #52. 

## Test code
```python
import pydarn

# Read in fitACF file. Works best with normalscan type data.
file = "20200507.0.fitacf"
SDarn_read = pydarn.SDarnRead(file)
fitacf_data = SDarn_read.read_fitacf()

# Sort into scans
beam_scan=pydarn.build_scan(fitacf_data)
print(beam_scan)
>>array([  1.,   1.,   1., ..., 720., 720., 720.])
```