### PR TITLE
Added flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+exclude = 
+    .git,
+    __pycache__,
+    build/,
+    # for now excluding this 
+    # file to avoid F401 files 
+    __init__.py

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,9 @@
+workflow "on check suite creation, run flake8 and post results" {
+    on = "pull_request"
+    resolves = "run flake8"
+}
+
+action "run flake8" {
+    uses = "tayfun/flake8-your-pr@master"
+    secrets = ["GITHUB_TOKEN"]
+}

--- a/setup.py
+++ b/setup.py
@@ -62,10 +62,7 @@ setup(
     author="SuperDARN",
     # used to import the logging config file into pydarn.
     include_package_data=True,
-    setup_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2'],
-    # pyyaml library install
-    install_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2']
-    # commented out due to not implemented yet.
-    #ext_modules = [rstmodule]
+    # setup_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2'],
+    install_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2', 'flake8']
 
 )


### PR DESCRIPTION
# Scope

Making it easier for developers to check their work is flake8 allowable. 

## test 

``` bash
flake8
```
long output but should look like something like this:
``` bash
setup.py:23:1: E302 expected 2 blank lines, found 1
setup.py:27:80: E501 line too long (81 > 79 characters)
setup.py:41:1: E305 expected 2 blank lines after class or function definition, found 1
setup.py:56:80: E501 line too long (83 > 79 characters)
setup.py:60:42: E231 missing whitespace after ','
```

