### PR TITLE
prdarnio import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     # used to import the logging config file into pydarn.
     include_package_data=True,
     # setup_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2'],
-    install_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2', 'flake8']
-
+    install_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2', 'flake8'],
+    extras_require={'io':['pydarnio']},
 )

--- a/setup.py
+++ b/setup.py
@@ -62,10 +62,7 @@ setup(
     author="SuperDARN",
     # used to import the logging config file into pydarn.
     include_package_data=True,
-    setup_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2'],
-    # pyyaml library install
-    install_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2']
-    # commented out due to not implemented yet.
-    #ext_modules = [rstmodule]
+    # setup_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2'],
+    install_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2', 'flake8']
 
 )

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,5 @@ setup(
     # used to import the logging config file into pydarn.
     include_package_data=True,
     # setup_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2'],
-    install_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2', 'flake8'],
-    extras_require={'io':['pydarnio']},
+    install_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2', 'pydarnio'],
 )


### PR DESCRIPTION
# Scope 

To test the import of pydarnio as an option to the user if they wish to use with pyDARN. 

## Test 

`pip3 install .[io]` 

should see pydarnio installed in the output. 

Cannot use `setup.py` will need to test later with PyPi. 

## Draft 

draft for now as I need to code more to get the pydarnio API working within pyDARN. 