### PR TITLE
Updating hardware exception

### DIFF
--- a/pydarn/exceptions/radar_exceptions.py
+++ b/pydarn/exceptions/radar_exceptions.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2020 SuperDARN Canada, University of Saskatchewan
 # Author(s): Marina Schmidt
 import logging
+import pydarn
+import os
 
 pydarn_log = logging.getLogger('pydarn')
 
@@ -12,11 +14,16 @@ class HardwareFileNotFoundError(Exception):
     """
     def __init__(self, abbrev):
         self.abbreviation = abbrev
-        self.message = "Hardware file for {} radar was not found."\
+        self.path = os.path.dirname(pydarn.__file__)
+        self.message = "Hardware file for {abv} radar was not found"\
+            " in {path}/utils/hdw/."\
             " Please insure the abbreviation is correct and there"\
             " exists a hardware file for it by checking:"\
-            " https://github.com/vtsuperdarn/hdw.dat"\
-            "".format(self.abbreviation)
-
+            " https://github.com/superdarn/hdw. If this error occurs when"\
+            " installing pydarn, please make an issue on the github page:"\
+            "https://github.com/SuperDARN/pydarn/issues/new so that"\
+            " developers are aware and can fix the problem."\
+            " Please note hardware files are not obtained by RST."\
+            "".format(abv=self.abbreviation, path=self.path)
         super().__init__(self.message)
         pydarn_log.error(self.message)

--- a/pydarn/exceptions/radar_exceptions.py
+++ b/pydarn/exceptions/radar_exceptions.py
@@ -17,7 +17,7 @@ class HardwareFileNotFoundError(Exception):
         self.path = os.path.dirname(pydarn.__file__)
         self.message = "Hardware file for {abv} radar was not found"\
             " in {path}/utils/hdw/."\
-            " Please insure the abbreviation is correct and there"\
+            " Please ensure the abbreviation is correct and there"\
             " exists a hardware file for it by checking:"\
             " https://github.com/superdarn/hdw. If this error occurs when"\
             " installing pydarn, please make an issue on the github page:"\


### PR DESCRIPTION
This PR is to address Issue #66 it includes the location of where the hardware files are, if the error is on install make an issue on github and this library does not use RST for hardware files. With the updated hardware link. 

Test:
```python 
import pydarn

pydarn.read_hdw_file('zzz')
```
```bash
resetting environment variable AACGM_v2_DAT_PREFIX in python script
non-default coefficient files may be specified by running aacgmv2.wrapper.set_coeff_path before any other functions
Hardware file for zzz radar was not found in /usr/lib/python3.6/site-packages/pydarn-1.1.0-py3.6.egg/pydarn/utils/hdw/. Please ensure the abbreviation is correct and there exists a hardware file for it by checking: https://github.com/superdarn/hdw. If this error occurs when installing pydarn, please make an issue on the github page:https://github.com/SuperDARN/pydarn/issues/new so that developers are aware and can fix the problem. Please note hardware files are not obtained by RST.
```
