### PR TITLE
Ehn/update hardware files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hdw"]
 	path = pydarn/utils/hdw
-	url = https://github.com/vtsuperdarn/hdw.dat
+	url = https://github.com/superdarn/hdw

--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -32,6 +32,7 @@ from .utils.superdarn_radars import SuperDARNRadars
 from .utils.superdarn_cpid import SuperDARNCpids
 from .utils.superdarn_radars import Hemisphere
 from .utils.superdarn_radars import read_hdw_file
+from .utils.superdarn_radars import get_hdw_files
 from .utils.scan import build_scan
 from .utils.radar_pos import radar_fov
 

--- a/pydarn/utils/superdarn_radars.py
+++ b/pydarn/utils/superdarn_radars.py
@@ -39,15 +39,23 @@ def get_hdw_files(force: bool = True, version: str = None):
     if version is not None:
         raise Exception("This feature is not implemented yet")
 
+    # if there is no files in hdw folder or force is true
+    # download the hdw files
     if len(os.listdir(hdw_path)) == 0 or force:
-
+        # pycurl doesn't download a zip folder easily so
+        # use the command line command
         check_call(['curl', '-L', '-o', hdw_path+'/master.zip',
                     'https://github.com/SuperDARN/hdw/archive/master.zip'])
-
+        # use unzip command because zipfile on works with files and not folders
+        # though this is possible with zipfile but this was easier for me to
+        # get it working
         check_call(['unzip', '-d', hdw_path, hdw_path+'/master.zip'])
         dat_files = glob.glob(hdw_path+'/hdw-master/*')
+        # shutil only moves specific files so we need to move
+        # everything one at a time
         for hdw_file in dat_files:
             shutil.move(hdw_file, hdw_path+os.path.basename(hdw_file))
+        # delete the empty folder
         os.removedirs(hdw_path+'/hdw-master/')
 
 
@@ -81,7 +89,10 @@ def read_hdw_file(abbrv, date: datetime = None, update: bool = False):
 
     hdw_path = os.path.dirname(__file__)+'/hdw/'
     hdw_file = "{path}/hdw.dat.{radar}".format(path=hdw_path, radar=abbrv)
-    get_hdw_files(False)
+    # if the file does not exist then try
+    # and download it
+    if os.path.exists(hdw_file) == False:
+        get_hdw_files()
     try:
         with open(hdw_file, 'r') as reader:
             for line in reader.readlines():

--- a/pydarn/utils/superdarn_radars.py
+++ b/pydarn/utils/superdarn_radars.py
@@ -6,10 +6,11 @@ This module contains SuperDARN radar information
 """
 import os
 
+import pydarn
+
 from typing import NamedTuple
 from enum import Enum
 from datetime import datetime, timedelta
-from pydarn import radar_exceptions
 from subprocess import check_call
 
 
@@ -38,10 +39,6 @@ def read_hdw_file(abbrv, date: datetime = None, update: bool = False):
     HardwareFileNotFoundError raised when there is no hardware file found for
     the given abbreviation
     """
-    if update:
-        print("Updating Hardware Files")
-        check_call(['git', 'submodule', 'update', '--init', '--recursive'])
-        check_call(['git', 'submodule', 'update', '--recursive', '--remote'])
     if date is None:
         date = datetime.now()
 
@@ -129,7 +126,7 @@ def read_hdw_file(abbrv, date: datetime = None, update: bool = False):
                                         float(hdw_data[16]),
                                         int(hdw_data[17]), int(hdw_data[18]))
     except FileNotFoundError:
-        raise radar_exceptions.HardwareFileNotFoundError(abbrv)
+        raise pydarn.radar_exceptions.HardwareFileNotFoundError(abbrv)
 
 
 class Hemisphere(Enum):

--- a/pydarn/utils/superdarn_radars.py
+++ b/pydarn/utils/superdarn_radars.py
@@ -10,9 +10,10 @@ from typing import NamedTuple
 from enum import Enum
 from datetime import datetime, timedelta
 from pydarn import radar_exceptions
+from subprocess import check_call
 
 
-def read_hdw_file(abbrv, date: datetime = None):
+def read_hdw_file(abbrv, date: datetime = None, update: bool = False):
     """
     Reads the hardware file for the associated abbreviation of the radar name.
 
@@ -23,7 +24,10 @@ def read_hdw_file(abbrv, date: datetime = None):
         date: datetime
             Datetime object of hardware information to obtain
             default: current date
-
+        update: bool
+            If True this will update the hardware files again
+            without re-installing pydarn
+            default: False
     Return
     ------
     _HdwInfo object that contains all the field names in a hardware
@@ -34,6 +38,10 @@ def read_hdw_file(abbrv, date: datetime = None):
     HardwareFileNotFoundError raised when there is no hardware file found for
     the given abbreviation
     """
+    if update:
+        print("Updating Hardware Files")
+        check_call(['git', 'submodule', 'update', '--init', '--recursive'])
+        check_call(['git', 'submodule', 'update', '--recursive', '--remote'])
     if date is None:
         date = datetime.now()
 
@@ -314,8 +322,8 @@ class SuperDARNRadars():
                          Hemisphere.North, read_hdw_file('hkw')),
               64: _Radar('Inuvik', 'University of Saskatchewan',
                          Hemisphere.North, read_hdw_file('inv')),
-              50: _Radar('Jiamusi East radar', 
-                         'National Space Science Center, Chinese Academy of Sciences', 
+              50: _Radar('Jiamusi East radar',
+                         'National Space Science Center, Chinese Academy of Sciences',
                          Hemisphere.North, read_hdw_file('jme')),
               3: _Radar('Kapuskasing', 'Virginia Tech', Hemisphere.North,
                         read_hdw_file('kap')),

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ class update_submodules(develop):
 class initialize_submodules(install):
     def run(self):
         if path.exists('.git'):
+            print("updating")
             check_call(['git', 'submodule', 'update', '--init', '--recursive'])
             check_call(['git', 'submodule', 'update', '--recursive', '--remote'])
         if self.old_and_unmanageable or self.single_version_externally_managed:

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,17 @@ import sys
 from os import path
 from setuptools import setup, find_packages
 from setuptools.command.install import install, orig
+from setuptools.command.develop import develop
 from glob import glob
 from subprocess import check_call
+
+class update_submodules(develop):
+    def run(self):
+        if path.exists('.git'):
+            check_call(['git', 'submodule', 'update', '--init', '--recursive'])
+            check_call(['git', 'submodule', 'update', '--recursive', '--remote'])
+        develop.run(self)
+
 
 # This class and function overrides the install python
 # setup method to add an extra git command in to install
@@ -44,7 +53,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 # Setup information
 setup(
-    cmdclass={'install': initialize_submodules},
+    cmdclass={'install': initialize_submodules, 'develop': update_submodules},
     name="pydarn",
     version="1.1.0",
     long_description=long_description,


### PR DESCRIPTION
Addressing issue #65 where I created `git_hdw_files`  which in the future could grab versions of the hdw files once DSWG implemented. 

However, for now, it `curls` and `unzip`s the master branch on https://github.com/superdarn/hdw which submodules is also updated. 

# Test 
Make sure not to install this under sudo, use -`-user` or python `virtualenv` instead  

```python
import pydarnn
pydarn.get_hdw_files()
```
output: 
``` bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   118  100   118    0     0    247      0 --:--:-- --:--:-- --:--:--   247
100 18098    0 18098    0     0  15246      0 --:--:--  0:00:01 --:--:-- 30989
Archive:  /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw//master.zip
34294ef63092442f6bbae227b6a7687a108e2127
   creating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/README.txt  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.ade  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.adw  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.bks  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.bpk  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.cly  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.cve  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.cvw  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.dce  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.dcn  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.ekb  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.fhe  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.fhw  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.fir  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.gbr  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.hal  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.han  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.hkw  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.hok  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.inv  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.jme  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.kap  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.ker  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.kod  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.ksr  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.lyr  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.mcm  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.pgr  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.pyk  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.rkn  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.san  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.sas  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.sch  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.sps  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.sto  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.sye  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.sys  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.tig  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.tst  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.unw  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.wal  
  inflating: /home/marina/.local/lib/python3.6/site-packages/pydarn/utils/hdw/hdw-master/hdw.dat.zho  
```
 
