### PR TITLE
fixed the warning message on fan plots

### DIFF
--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -42,4 +42,3 @@ from .plotting.rtp import RTP
 from .plotting.fan import Fan
 from .plotting.acf import ACF
 from .plotting.power import Power
-from .plotting.grid import Grid

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -293,6 +293,9 @@ class Fan():
             else:
                 ax.set_ylim(-90, -abs(lowlat))
                 ax.set_yticks(np.arange(-abs(lowlat), -90, -10))
+            ax.set_xticks([0, np.radians(45), np.radians(90), np.radians(135),
+                           np.radians(180), np.radians(225), np.radians(270),
+                           np.radians(315)])
             ax.set_xticklabels(['00', '', '06', '', '12', '', '18', ''])
             ax.set_theta_zero_location("S")
 


### PR DESCRIPTION
# Scope 

fixing the following `Userwarning`:
`UserWarning: FixedFormatter should only be used together with FixedLocator` 

**issue**: #104 

## Approval

**Number of approvals:** 1 this is a  1 liner fix

##  Test 

``` python
import matplotlib.pyplot as plt 
import datetime as dt
import pydarn

#Read in fitACF file
fitacf_file = "20100305.0001.00.inv.fitacf"
fitacf_data = pydarn.SuperDARNRead(fitacf_file).read_fitacf()

fanplot = pydarn.Fan.plot_fan(fitacf_data)
plt.show()
```

![Figure_1](https://user-images.githubusercontent.com/6520530/110702428-1cad0a00-81b8-11eb-9a84-2ace216be3a4.png)


and no `userwarning`  message should appear
