### PR TITLE
FIX/Offset between major and minor ticks using slant range in RTPs

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -399,7 +399,8 @@ class RTP():
         ax.set_ylim(ymin, ymax)
 
         if slant:
-            ax.yaxis.set_ticks(np.arange(np.ceil(ymin / 100.0) * 100, ymax+1, yspacing))
+            ax.yaxis.set_ticks(np.arange(np.ceil(ymin/100.0)*100,
+                                         ymax+1, yspacing))
         else:
             ax.yaxis.set_ticks(np.arange(ymin, ymax+1, (ymax)/5))
 

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -415,7 +415,7 @@ class RTP():
             tick_interval = 1
         ax.xaxis.set_minor_locator(dates.MinuteLocator(interval=tick_interval))
         if slant:
-            ax.yaxis.set_minor_locator(ticker.MultipleLocator(100))
+            ax.yaxis.set_minor_locator(ticker.AutoMinorLocator(2))
         else:
             ax.yaxis.set_minor_locator(ticker.MultipleLocator(5))
         # so the plots gets to the ends

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -399,7 +399,7 @@ class RTP():
         ax.set_ylim(ymin, ymax)
 
         if slant:
-            ax.yaxis.set_ticks(np.arange(ymin, ymax+1, yspacing))
+            ax.yaxis.set_ticks(np.arange(np.ceil(ymin / 100.0) * 100, ymax+1, yspacing))
         else:
             ax.yaxis.set_ticks(np.arange(ymin, ymax+1, (ymax)/5))
 


### PR DESCRIPTION
# Scope 

To fix issue #126 

Fix for the offset between the major and minor ticks when using the slant=True option for RTP and subsequently summary plots. The minor ticks are now set to be in the middle of the major ticks. Previous to this, the ticks were set at every 100, so they may look more sparse on the summary plots as there would have been 4 minor ticks between each major tick, and now there is just 1 minor tick.
I have also included a quick change to the major ticks so that they show up on the nearest hundred and increase each 200 for RTP (still increase at 500 on summary plots but are rounded to nearest hundred too, possible future change to make summary plots put ticks on the nearest 500th unit?), mainly for neatness and ease of the user to read off the axis. 

## Approval

**Number of approvals:** 2 

*Reminder, please check your code is:
  - copyrighted (if applicable)
  - Appropriate disclaimer added
  - Modification line filled in (if applicable)*

Not modified the header of rtp.py as I'm not sure if it's still in the old style or not?

Example new RT plot axis:
![Screen Shot 2021-03-19 at 4 16 21 PM](https://user-images.githubusercontent.com/60905856/111847472-7a370a00-88ce-11eb-9f13-e1c8ead5b7a2.png)
Example new summary plot axis:
![Screen Shot 2021-03-19 at 4 15 54 PM](https://user-images.githubusercontent.com/60905856/111847487-8327db80-88ce-11eb-80ae-fefd45d6ba43.png)
Above plots made with:
```python
import matplotlib.pyplot as plt 
import pydarn

#Load in dmap file
file = "/Users/carley/Documents/data/20161123.1601.00.mcm.a.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()
#Plot and show
a = pydarn.RTP.plot_range_time(fitacf_data, beam_num=4, slant=True)
#a = pydarn.RTP.plot_summary(fitacf_data, beam_num=2, slant=True)
plt.show()
```
