### PR TITLE
Fix for dropped beam in plot_fan and plot_fov

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -179,8 +179,8 @@ class Fan():
             zmax = defaultzminmax[parameter][1]
 
         # Begin plotting by iterating over ranges and beams
-        for gates in range(ranges[0], ranges[1]-1):
-            for beams in range(thetas.shape[1] - 2):
+        for gates in range(ranges[0], ranges[1] - 1):
+            for beams in range(thetas.shape[1] - 1):
                 # Index colour table correctly
                 cmapindex = (scan[gates, beams] + abs(zmin)) /\
                         (abs(zmin) + abs(zmax))
@@ -304,16 +304,16 @@ class Fan():
             plt.polar(thetas[0:ranges[1], 0], rs[0:ranges[1], 0],
                       color='black', linewidth=0.5)
             # top radar arc
-            plt.polar(thetas[ranges[1] - 1, 0:thetas.shape[1] - 1],
-                      rs[ranges[1] - 1, 0:thetas.shape[1] - 1],
+            plt.polar(thetas[ranges[1] - 1, 0:thetas.shape[1]],
+                      rs[ranges[1] - 1, 0:thetas.shape[1]],
                       color='black', linewidth=0.5)
             # right boundary line
-            plt.polar(thetas[0:ranges[1], thetas.shape[1] - 2],
-                      rs[0:ranges[1], thetas.shape[1] - 2],
+            plt.polar(thetas[0:ranges[1], thetas.shape[1] - 1],
+                      rs[0:ranges[1], thetas.shape[1] - 1],
                       color='black', linewidth=0.5)
             # bottom arc
-            plt.polar(thetas[0, 0:thetas.shape[1] - 2],
-                      rs[0, 0:thetas.shape[1] - 2], color='black',
+            plt.polar(thetas[0, 0:thetas.shape[1] - 1],
+                      rs[0, 0:thetas.shape[1] - 1], color='black',
                       linewidth=0.5)
 
         if fov_color is not None:


### PR DESCRIPTION
# Scope 

Fixes issue where a beam worth of data was dropped, and where the top arc of the radar FOV was plotted one range gate too low. Described in more detail in issue #139. 

## Approval

**Number of approvals:** 1

## Test

```python
file='20170731.2202.00.inv.fitacf'
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()
fanplot = pydarn.Fan.plot_fan(fitacf_data)
plt.show()	
```
Compared with current develop branch, one more beam of data should be visible on the rightmost portion of the FOV
