### PR TITLE
FIX: Get rxrise from hdw

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -336,7 +336,10 @@ class RTP():
                                      end_time=end_time,
                                      opt_beam_num=cls.dmap_data[0]['bmnum'])
         if coord is Coord.SLANT_RANGE:
-            y = gate2slant(cls.dmap_data[0], y_max)
+            # Get rxrise from hardware files (consistent with RST)
+            rxrise = SuperDARNRadars.radars[cls.dmap_data[0]['stid']]\
+                                    .hardware_info.rx_rise_time
+            y = gate2slant(cls.dmap_data[0], y_max, rxrise=rxrise)
         time_axis, y_axis = np.meshgrid(x, y)
         z_data = np.ma.masked_where(np.isnan(z.T), z.T)
         Default = {'noise.sky': (1e0, 1e5),

--- a/pydarn/utils/conversions.py
+++ b/pydarn/utils/conversions.py
@@ -82,7 +82,7 @@ def dmap2dict(dmap_records: List[dict]) -> List[dict]:
     return dmap_list
 
 
-def gate2slant(record, nrang, center=True):
+def gate2slant(record, nrang, rxrise=0, center=True):
     """
     Calculate the slant range (km) for each range gate for SuperDARN data
 
@@ -92,6 +92,9 @@ def gate2slant(record, nrang, center=True):
             dictionary of superdarn data records
         nrang: int
             max number of range gates in the list of records
+        rxrise: int
+            analog Rx rise time measured in microseconds
+            Default = 0
         center: boolean
             Calculate the slant range in the center of range gate
             or edge
@@ -122,7 +125,7 @@ def gate2slant(record, nrang, center=True):
     # Now calculate slant range in km
     slant_ranges = np.zeros(nrang+1)
     for gate in range(nrang+1):
-        slant_ranges[gate] = (lag_first - record['rxrise'] +
+        slant_ranges[gate] = (lag_first - rxrise +
                               gate * sample_sep) * speed_of_light /\
                 distance_factor + range_offset
     return slant_ranges


### PR DESCRIPTION
# Scope 

Gets the Rx rise time using `SuperDARNRadars.radar[stid].hardware_info.rx_rise_time` in the `plot_range_time` function in `rtp.py` when plotting.
This value gets passed to `gate2slant` and that gets used as the rxrise variable in the calculation. 

An alternative would be to grab the rxrise from the hardware files inside the `gate2slant` function, however I had trouble importing `SuperDARNRadars` from `pydarn` in `conversions.py` and assumed as we already import it in `rtp.py` it would fit better there and give a wider range of use, allowing people to give inputs to `gate2slant` maybe down the line. This also allows us to set a default value of 0 if the Rx rise time is not given in the function call. 

Getting the Rx rise time from hardware was chosen as previous discrepancies exist between hardware and FITACF files. This is outside the remit of pyDARN so for consistency/until the discrepancies are resolved, we will be using the same process as RST. 

To close #147 

## Approval

2

## Test
I've just been testing with this snippet between range time plotting and summary plotting. 
```python
import matplotlib.pyplot as plt 
import pydarn

#Load in dmap file
file = "/data/20150305.0601.00.inv.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

#a = pydarn.RTP.plot_range_time(fitacf_data, beam_num=5)
a = pydarn.RTP.plot_summary(fitacf_data, beam_num=2, coord=pydarn.Coord.SLANT_RANGE)
plt.show()
```
You should see very little difference from before, but if you print out the lowest range gate it should now be at the right (or same place as RST gets it) place for some radars that have the discrepancy between hdw and FITACF files. 
Let me know if I need to change any modification headers/ let me know if there are any situations in which an rxrise would not be able to be found (i.e. should rxrise be inside a try loop so we can except with a value of 0 if it breaks?)

**This will definitely have a conflict with the fix in #134 as the new kwarg is in the same place as the center=False is in the call to `gate2slant`: we will need both of these kwargs in the function call when the time comes for merging.**

There was also talk of adding a warning to users about this, what should that warning say?/ Where should be note this in the documentation?