### PR TITLE
Ehn/rtp ground scatter range

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Python data visualization library for the Super Dual Auroral Radar Network (SuperDARN).
 
-!!! Warning
+**WARNING!**
     This is the `develop` branch that is not DOI'd yet, please click on the above DOI to get the most recently released pyDARN version. 
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 Python data visualization library for the Super Dual Auroral Radar Network (SuperDARN).
 
+!!! Warning
+    This is the `develop` branch that is not DOI'd yet, please click on the above DOI to get the most recently released pyDARN version. 
+
 ## Changelog
 
 ## Version 2.0.1 - Release!

--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -27,7 +27,7 @@ from .exceptions.warning_formatting import citing_warning
 # importing utils
 from .utils.conversions import dmap2dict
 from .utils.conversions import gate2slant
-from .utils.conversions import gateGroundScatter
+from .utils.conversions import gate2GroundScatter
 from .utils.plotting import check_data_type
 from .utils.plotting import time2datetime
 from .utils.superdarn_radars import SuperDARNRadars

--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -36,7 +36,7 @@ from .utils.superdarn_radars import read_hdw_file
 from .utils.superdarn_radars import get_hdw_files
 from .utils.scan import build_scan
 from .utils.radar_pos import radar_fov
-from .utils.coordinates import Coord
+from .utils.coordinates import Coords
 
 # import plotting
 from .plotting.color_maps import PyDARNColormaps

--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -27,6 +27,7 @@ from .exceptions.warning_formatting import citing_warning
 # importing utils
 from .utils.conversions import dmap2dict
 from .utils.conversions import gate2slant
+from .utils.conversions import gateGroundScatter
 from .utils.plotting import check_data_type
 from .utils.plotting import time2datetime
 from .utils.superdarn_radars import SuperDARNRadars

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 from matplotlib import dates, colors, cm, ticker
 from typing import List
 
-from pydarn import (gate2slant, check_data_type, time2datetime,
+from pydarn import (gateGroundScatter, gate2slant, check_data_type, time2datetime,
                     rtp_exceptions, plot_exceptions, SuperDARNCpids,
                     SuperDARNRadars, standard_warning_format,
                     PyDARNColormaps, Coords, citing_warning)
@@ -351,7 +351,7 @@ class RTP():
                                     .hardware_info.rx_rise_time
             y = gate2slant(cls.dmap_data[0], y_max, rxrise=rxrise)
             Re = 6371
-            y = Re*np.arcsin(np.sqrt((y**2/4)-(hgt**2))/Re)  
+            y = gateGroundScatter(y, Re, hgt)
             y0inx = np.min(np.where(np.isfinite(y))[0])
             y = y[y0inx:]
             z = z[:,y0inx:]
@@ -416,6 +416,9 @@ class RTP():
         ax.set_ylim(ymin, ymax)
 
         if coord is Coords.SLANT_RANGE:
+            ax.yaxis.set_ticks(np.arange(np.ceil(ymin/100.0)*100,
+                                         ymax+1, yspacing))
+        elif coord is Coords.GROUND_SCATTER_MAPPED_RANGE:
             ax.yaxis.set_ticks(np.arange(np.ceil(ymin/100.0)*100,
                                          ymax+1, yspacing))
         else:

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -56,7 +56,8 @@ class RTP():
                         start_time: datetime = None, end_time: datetime = None,
                         colorbar: plt.colorbar = None, ymin: int = None,
                         ymax: int = None, yspacing: int = 200,
-                        coord: object = Coords.SLANT_RANGE, colorbar_label: str = '',
+                        coord: object = Coords.SLANT_RANGE, hgt = 250, 
+                        colorbar_label: str = '',
                         norm=colors.Normalize,
                         cmap: str = None,
                         filter_settings: dict = {},
@@ -109,9 +110,13 @@ class RTP():
         yspacing: int
             sets the spacing between ticks
             Default: 200
-        coord: Coord
+        coord: Coords
             set the y-axis to a desired coordinate system
-            Default: Coord.SLANT_RANGE
+            Default: Coords.SLANT_RANGE
+        hgt: int
+            set the ionosphere virtual reflection height
+            this only applies to Coords.GROUND_SCATTER_MAPPED_RANGE
+            Default: 250 (km)
         norm: matplotlib.colors.Normalization object
             This object use dependency injection to use any normalization
             method with the zmin and zmax.
@@ -341,7 +346,6 @@ class RTP():
         elif coord is Coords.GROUND_SCATTER_MAPPED_RANGE:
             y = gate2slant(cls.dmap_data[0], y_max)
             Re = 6371
-            hgt = 250
             y = Re*np.arcsin(np.sqrt((y**2/4)-(hgt**2))/Re)  
             y0inx = np.min(np.where(np.isfinite(y))[0])
             y = y[y0inx:]

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -437,6 +437,8 @@ class RTP():
         ax.xaxis.set_minor_locator(dates.MinuteLocator(interval=tick_interval))
         if coord is Coords.SLANT_RANGE:
             ax.yaxis.set_minor_locator(ticker.AutoMinorLocator(2))
+        if coord is Coords.GROUND_SCATTER_MAPPED_RANGE:
+            ax.yaxis.set_minor_locator(ticker.AutoMinorLocator(2))
         else:
             ax.yaxis.set_minor_locator(ticker.MultipleLocator(5))
         # so the plots gets to the ends

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 from matplotlib import dates, colors, cm, ticker
 from typing import List
 
-from pydarn import (gate2GroundScatter, gate2slant, check_data_type, time2datetime,
+from pydarn import (Re,gate2GroundScatter, gate2slant, check_data_type, time2datetime,
                     rtp_exceptions, plot_exceptions, SuperDARNCpids,
                     SuperDARNRadars, standard_warning_format,
                     PyDARNColormaps, Coords, citing_warning)
@@ -350,7 +350,6 @@ class RTP():
             rxrise = SuperDARNRadars.radars[cls.dmap_data[0]['stid']]\
                                     .hardware_info.rx_rise_time
             y = gate2slant(cls.dmap_data[0], y_max, rxrise=rxrise)
-            Re = 6371
             y = gate2GroundScatter(y, Re, reflection_height)
             y0inx = np.min(np.where(np.isfinite(y))[0])
             y = y[y0inx:]

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -56,7 +56,7 @@ class RTP():
                         start_time: datetime = None, end_time: datetime = None,
                         colorbar: plt.colorbar = None, ymin: int = None,
                         ymax: int = None, yspacing: int = 200,
-                        coord: object = Coords.SLANT_RANGE, float: reflection_height = 250., 
+                        coord: object = Coords.SLANT_RANGE, reflection_height: float = 250.0, 
                         colorbar_label: str = '',
                         norm=colors.Normalize,
                         cmap: str = None,

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -699,7 +699,7 @@ class RTP():
     @classmethod
     def plot_summary(cls, dmap_data: List[dict], beam_num: int = 0,
                      groundscatter: bool = True, channel: int = 'all',
-                     coord: object = Coords.SLANT_RANGE, figsize: tuple = (11, 8.5),
+                     coord: object = Coords.SLANT_RANGE, hgt: float = 250.0, figsize: tuple = (11, 8.5),
                      watermark: bool = True, boundary: dict = {},
                      background_color: str = 'w', cmaps: dict = {},
                      lines: dict = {}, plot_elv: bool = True, title=None):
@@ -734,6 +734,10 @@ class RTP():
         coord: Coord
             set the y-axis to a desired coordinate system
             Default: Coord.SLANT_RANGE
+        hgt: int
+            set the ionosphere virtual reflection height
+            this only applies to Coords.GROUND_SCATTER_MAPPED_RANGE
+            Default: 250 (km)
         figsize : (int,int)
             tuple containing (height, width) figure size
             Default: 11 x 8.5
@@ -1008,7 +1012,8 @@ class RTP():
                                             ax=axes[i],
                                             groundscatter=grndflg,
                                             channel=channel,
-                                            coord=coord,
+                                            coord=coord, 
+                                            hgt = hgt,
                                             cmap=cmap[axes_parameters[i]],
                                             zmin=boundary_ranges[axes_parameters[i]][0],
                                             zmax=boundary_ranges[axes_parameters[i]][1],

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -982,6 +982,8 @@ class RTP():
                 # on the velocity plot. This may change in the future.
                 if coord is Coords.SLANT_RANGE:
                     ymax = 3517.5
+                elif coord is Coords.GROUND_SCATTER_MAPPED_RANGE:
+                    ymax = 3517.5/2
                 else:
                     ymax = 75
                 if groundscatter and axes_parameters[i] == 'v':
@@ -1024,6 +1026,8 @@ class RTP():
                     cbar.set_ticks(ticks)
                 if coord is Coords.SLANT_RANGE:
                     axes[i].set_ylabel('Slant Range (km)')
+                elif coord is Coords.GROUND_SCATTER_MAPPED_RANGE:
+                    axes[i].set_ylabel('Ground Scatter\nMapped Range\n(km)')
                 else:
                     axes[i].set_ylabel('Range Gates')
             if i < num_plots-1:

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -351,7 +351,7 @@ class RTP():
                                     .hardware_info.rx_rise_time
             y = gate2slant(cls.dmap_data[0], y_max, rxrise=rxrise)
             Re = 6371
-            y = gateGroundScatter(y, Re, hgt)
+            y = gate2GroundScatter(y, Re, reflection_height)
             y0inx = np.min(np.where(np.isfinite(y))[0])
             y = y[y0inx:]
             z = z[:,y0inx:]

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -56,7 +56,7 @@ class RTP():
                         start_time: datetime = None, end_time: datetime = None,
                         colorbar: plt.colorbar = None, ymin: int = None,
                         ymax: int = None, yspacing: int = 200,
-                        coord: object = Coords.SLANT_RANGE, hgt = 250, 
+                        coord: object = Coords.SLANT_RANGE, reflection_height = 250, 
                         colorbar_label: str = '',
                         norm=colors.Normalize,
                         cmap: str = None,

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 from matplotlib import dates, colors, cm, ticker
 from typing import List
 
-from pydarn import (gateGroundScatter, gate2slant, check_data_type, time2datetime,
+from pydarn import (gate2GroundScatter, gate2slant, check_data_type, time2datetime,
                     rtp_exceptions, plot_exceptions, SuperDARNCpids,
                     SuperDARNRadars, standard_warning_format,
                     PyDARNColormaps, Coords, citing_warning)

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -2,6 +2,20 @@
 # Author: Marina Schmidt
 # This code is improvement based on rti.py in the DaVitpy library
 # https://github.com/vtsuperdarn/davitpy/blob/master/davitpy
+#
+# Modifications:
+# 2021-05-12 Francis Tholley added gate2grounscatter to range-time plots
+#
+# Disclaimer:
+# pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
+# Everyone is permitted to copy and distribute verbatim copies of this license
+# document, but changing it is not allowed.
+#
+# This version of the GNU Lesser General Public License incorporates the terms
+# and conditions of version 3 of the GNU General Public License,
+# supplemented by the additional permissions listed below.
+#
+
 
 """
 Range-Time Parameter (aka Intensity) plots
@@ -14,10 +28,11 @@ from datetime import datetime, timedelta
 from matplotlib import dates, colors, cm, ticker
 from typing import List
 
-from pydarn import (gate2GroundScatter, gate2slant, check_data_type, time2datetime,
-                    rtp_exceptions, plot_exceptions, SuperDARNCpids,
-                    SuperDARNRadars, standard_warning_format,
-                    PyDARNColormaps, Coords, citing_warning)
+from pydarn import (gate2GroundScatter, gate2slant, check_data_type,
+                    time2datetime, rtp_exceptions, plot_exceptions,
+                    SuperDARNCpids, SuperDARNRadars,
+                    standard_warning_format, PyDARNColormaps,
+                    Coords, citing_warning)
 
 warnings.formatwarning = standard_warning_format
 
@@ -56,7 +71,7 @@ class RTP():
                         start_time: datetime = None, end_time: datetime = None,
                         colorbar: plt.colorbar = None, ymin: int = None,
                         ymax: int = None, yspacing: int = 200,
-                        coord: object = Coords.SLANT_RANGE, reflection_height: float = 250.0, 
+                        coord: object = Coords.SLANT_RANGE, reflection_height: float = 250.0,
                         colorbar_label: str = '',
                         norm=colors.Normalize,
                         cmap: str = None,
@@ -730,7 +745,7 @@ class RTP():
         coord: Coord
             set the y-axis to a desired coordinate system
             Default: Coord.SLANT_RANGE
-        reflection_height: float 
+        reflection_height: float
             set the ionosphere virtual reflection height
             this only applies to Coords.GROUND_SCATTER_MAPPED_RANGE
             Default: 250 (km)
@@ -1008,7 +1023,7 @@ class RTP():
                                             ax=axes[i],
                                             groundscatter=grndflg,
                                             channel=channel,
-                                            coord=coord, 
+                                            coord=coord,
                                             reflection_height = reflection_height,
                                             cmap=cmap[axes_parameters[i]],
                                             zmin=boundary_ranges[axes_parameters[i]][0],

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -113,7 +113,7 @@ class RTP():
         coord: Coords
             set the y-axis to a desired coordinate system
             Default: Coords.SLANT_RANGE
-        hgt: int
+        reflection_height: int
             set the ionosphere virtual reflection height
             this only applies to Coords.GROUND_SCATTER_MAPPED_RANGE
             Default: 250 (km)

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -435,9 +435,7 @@ class RTP():
         else:
             tick_interval = 1
         ax.xaxis.set_minor_locator(dates.MinuteLocator(interval=tick_interval))
-        if coord is Coords.SLANT_RANGE:
-            ax.yaxis.set_minor_locator(ticker.AutoMinorLocator(2))
-        if coord is Coords.GROUND_SCATTER_MAPPED_RANGE:
+        if coord is Coords.SLANT_RANGE or coord is Coords.GROUND_SCATTER_MAPPED_RANGE:
             ax.yaxis.set_minor_locator(ticker.AutoMinorLocator(2))
         else:
             ax.yaxis.set_minor_locator(ticker.MultipleLocator(5))

--- a/pydarn/utils/conversions.py
+++ b/pydarn/utils/conversions.py
@@ -84,26 +84,32 @@ def dmap2dict(dmap_records: List[dict]) -> List[dict]:
         dmap_list.append(OrderedDict(dmap_dict))
     return dmap_list
 
-def gate2GroundScatter(y, reflection_height=250):
+
+def gate2GroundScatter(slant_ranges: List[float],
+                       reflection_height: float = 250):
     """
-    Calculate the ground scatter mapped range (km) for each range gate for SuperDARN data
-    This function is based on the Ground Scatter equation from Bristow paper at https://doi.org/10.1029/93JA01470 on page 325
+    Calculate the ground scatter mapped range (km) for each slanted range
+    for SuperDARN data . This function is based on the Ground Scatter equation
+    from Bristow paper at https://doi.org/10.1029/93JA01470 on page 325
     Parameters
     ----------
-        Re: float
-            earth's radius
-        hgt: float
+        slant_ranges : List[float]
+            list of slant ranges
+        reflection_height: float
             reflection height
+            default:  250
 
     Returns
     -------
         ground_scatter_mapped_ranges : np.array
             returns an array of ground scatter mapped ranges for the radar
     """
-   
-    y = Re*np.arcsin(np.sqrt((y**2/4)-(reflection_height**2))/Re)  
 
-    return y
+    ground_scatter_mapped_ranges =\
+        Re*np.arcsin(np.sqrt((slant_ranges**2/4)-(reflection_height**2))/Re)
+
+    return ground_scatter_mapped_ranges
+
 
 def gate2slant(record, nrang, rxrise=0, center=False):
     """
@@ -151,4 +157,3 @@ def gate2slant(record, nrang, rxrise=0, center=False):
                               gate * sample_sep) * speed_of_light /\
                 distance_factor + range_offset
     return slant_ranges
-    

--- a/pydarn/utils/conversions.py
+++ b/pydarn/utils/conversions.py
@@ -1,6 +1,7 @@
 # Copyright 2019 SuperDARN Canada, University of Saskatchewan
 # Author: Marina Schmidt
-
+# Copyright 2021 University of Scranton
+# Author: Francis Tholley and Dr. Nathaniel Frissel for gate2groundscatter
 """
 This module is to focus on data conversions
 

--- a/pydarn/utils/conversions.py
+++ b/pydarn/utils/conversions.py
@@ -81,7 +81,26 @@ def dmap2dict(dmap_records: List[dict]) -> List[dict]:
         dmap_list.append(OrderedDict(dmap_dict))
     return dmap_list
 
+def gateGroundScatter(y, Re, hgt=250):
+    """
+    Calculate the ground scatter mapped range (km) for each range gate for SuperDARN data
 
+    Parameters
+    ----------
+        Re: int
+            earth's radius
+        hgt: int
+            reflection height
+
+    Returns
+    -------
+        ground_scatter_mapped_ranges : np.array
+            returns an array of ground scatter mapped ranges for the radar
+    """
+    # Ground Scatter equation can be found on Bristow paper at https://doi.org/10.1029/93JA01470 on page 325
+    y = Re*np.arcsin(np.sqrt((y**2/4)-(hgt**2))/Re)  
+
+    return y
 
 def gate2slant(record, nrang, rxrise=0, center=False):
     """
@@ -128,3 +147,5 @@ def gate2slant(record, nrang, rxrise=0, center=False):
                               gate * sample_sep) * speed_of_light /\
                 distance_factor + range_offset
     return slant_ranges
+    
+

--- a/pydarn/utils/conversions.py
+++ b/pydarn/utils/conversions.py
@@ -81,10 +81,10 @@ def dmap2dict(dmap_records: List[dict]) -> List[dict]:
         dmap_list.append(OrderedDict(dmap_dict))
     return dmap_list
 
-def gateGroundScatter(y, Re, hgt=250):
+def gate2GroundScatter(y, Re, reflection_height=250):
     """
     Calculate the ground scatter mapped range (km) for each range gate for SuperDARN data
-
+    This function is based on the Ground Scatter equation from Bristow paper at https://doi.org/10.1029/93JA01470 on page 325
     Parameters
     ----------
         Re: float
@@ -97,8 +97,8 @@ def gateGroundScatter(y, Re, hgt=250):
         ground_scatter_mapped_ranges : np.array
             returns an array of ground scatter mapped ranges for the radar
     """
-    # Ground Scatter equation can be found on Bristow paper at https://doi.org/10.1029/93JA01470 on page 325
-    y = Re*np.arcsin(np.sqrt((y**2/4)-(hgt**2))/Re)  
+   
+    y = Re*np.arcsin(np.sqrt((y**2/4)-(reflection_height**2))/Re)  
 
     return y
 

--- a/pydarn/utils/conversions.py
+++ b/pydarn/utils/conversions.py
@@ -87,9 +87,9 @@ def gateGroundScatter(y, Re, hgt=250):
 
     Parameters
     ----------
-        Re: int
+        Re: float
             earth's radius
-        hgt: int
+        hgt: float
             reflection height
 
     Returns
@@ -148,4 +148,3 @@ def gate2slant(record, nrang, rxrise=0, center=False):
                 distance_factor + range_offset
     return slant_ranges
     
-

--- a/pydarn/utils/coordinates.py
+++ b/pydarn/utils/coordinates.py
@@ -20,7 +20,7 @@ plotting
 """
 import enum
 
-class Coord(enum.Enum):
+class Coords(enum.Enum):
     """
     This coordinate class is to list the current coordinate systems
     a user can pick from
@@ -28,7 +28,9 @@ class Coord(enum.Enum):
     enumerators:
         RANGE_GATE: range gates
         SLANT_RANGE: slant range (km)
+        GROUND_SCATTER_MAPPED_RANGE: ground scatter mapped range (km)
     """
 
     RANGE_GATE = enum.auto()
     SLANT_RANGE = enum.auto()
+    GROUND_SCATTER_MAPPED_RANGE = enum.auto()


### PR DESCRIPTION
# Scope 
This pull request enables pydarn to use the ground scatter mapped range coordinate system when plotting rtp plots. This is the coordinate system described in https://doi.org/10.1029/93JA01470 on page 324.

## Approval

**Number of approvals:** 2

## Test
```
import pydarnio
import pydarn
from matplotlib import pyplot as plt
from pydarn import Coords

fitacf_file = 'data_vt_sps/20170101.0000.02.sps.a.fitacf'
fitacf_reader = pydarnio.SDarnRead(fitacf_file)
fitacf_data = fitacf_reader.read_fitacf()
pydarn.RTP.plot_range_time(fitacf_data, beam_num=7, parameter='p_l', zmax=50, zmin=0, date_fmt='%H%M',
                 colorbar_label='Power (dB)', cmap='viridis', coord = Coords.GROUND_SCATTER_MAPPED_RANGE, hgt = 250)
plt.savefig('test1.png')
```