### PR TITLE
Polar plots modularity

### DIFF
--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -40,7 +40,9 @@ from .utils.coordinates import Coord
 
 # import plotting
 from .plotting.color_maps import PyDARNColormaps
+from .plotting.axis import Projections
 from .plotting.rtp import RTP
 from .plotting.fan import Fan
 from .plotting.acf import ACF
 from .plotting.power import Power
+

--- a/pydarn/plotting/axis.py
+++ b/pydarn/plotting/axis.py
@@ -35,7 +35,7 @@ class Projections():
                 "   - axis_polar()\n"
 
     @classmethod
-    def axis_polar(cls, lowlat: int = 30, hem: str = Hemisphere.North):
+    def axis_polar(cls, lowlat: int = 30, hem: object = Hemisphere.North):
         """
         Plots a radar's Field Of View (FOV) fan plot for the given data and
         scan number

--- a/pydarn/plotting/axis.py
+++ b/pydarn/plotting/axis.py
@@ -38,19 +38,41 @@ class Projections():
                 "   - axis_polar()\n"
 
     @classmethod
-    def axis_polar(cls, ax=None):
+    def axis_polar(cls, lowlat: int = 30, hem: str='N'):
         """
         Plots a radar's Field Of View (FOV) fan plot for the given data and
         scan number
 
         Parameters
         -----------
-            dmap_data: List[dict]
-                asda
-        """                
-             
-        pdb.set_trace()  
+            lowlat: int
+                Lower AACGM latitude boundary for the polar plot
+                Default: 30
+            hem: str
+                Hemisphere of polar projection. Can be 'N' or 'S' for
+                northern and southern hemispheres, respectively
+                Default: 'N'
+                
+        """                    
         
+        ax = plt.axes(polar=True)
+
+        # Set upper and lower latitude limits (pole and lowlat)
+        if hem is 'N':
+            ax.set_ylim(90, lowlat)
+            ax.set_yticks(np.arange(lowlat, 90, 10))
+        else:
+            ax.set_ylim(-90, -abs(lowlat)) # If hem is 'S', lowlat must be negative
+            ax.set_yticks(np.arange(-abs(lowlat), -90, -10))
+         
+        # Locations of tick marks. Will be customisable in future    
+        ax.set_xticks([0, np.radians(45), np.radians(90), np.radians(135),
+                       np.radians(180), np.radians(225), np.radians(270),
+                       np.radians(315)])
+                       
+        # Tick labels will depend on coordinate system               
+        ax.set_xticklabels(['00', '', '06', '', '12', '', '18', ''])
+        ax.set_theta_zero_location("S")
         
         return ax       
                  

--- a/pydarn/plotting/axis.py
+++ b/pydarn/plotting/axis.py
@@ -18,6 +18,8 @@ Code which generates axis objects for use in plotting functions
 import matplotlib.pyplot as plt
 import numpy as np
 
+from pydarn import Hemisphere
+
 
 class Projections():
     """
@@ -33,7 +35,7 @@ class Projections():
                 "   - axis_polar()\n"
 
     @classmethod
-    def axis_polar(cls, lowlat: int = 30, hem: str = 'N'):
+    def axis_polar(cls, lowlat: int = 30, hem: str = Hemisphere.North):
         """
         Plots a radar's Field Of View (FOV) fan plot for the given data and
         scan number
@@ -43,16 +45,17 @@ class Projections():
             lowlat: int
                 Lower AACGM latitude boundary for the polar plot
                 Default: 30
-            hem: str
-                Hemisphere of polar projection. Can be 'N' or 'S' for
-                northern and southern hemispheres, respectively
-                Default: 'N'
+            hem: enum
+                Hemisphere of polar projection. Can be Hemisphere.North or 
+                Hemisphere.South for northern and southern hemispheres, 
+                respectively
+                Default: Hemisphere.North
         """
 
         ax = plt.axes(polar=True)
 
         # Set upper and lower latitude limits (pole and lowlat)
-        if hem is 'N':
+        if hem is Hemisphere.North:
             ax.set_ylim(90, lowlat)
             ax.set_yticks(np.arange(lowlat, 90, 10))
         else:

--- a/pydarn/plotting/axis.py
+++ b/pydarn/plotting/axis.py
@@ -15,14 +15,8 @@
 Code which generates axis objects for use in plotting functions
 """
 
-import datetime as dt
 import matplotlib.pyplot as plt
 import numpy as np
-from typing import List
-import pdb
-
-# Third party libraries
-import aacgmv2
 
 class Projections():
     """
@@ -35,7 +29,7 @@ class Projections():
     def __str__(self):
         return "This class is static class that provides"\
                 " the following methods: \n"\
-                "   - axis_polar()\n"
+                "   - axis_polar()\n"\
 
     @classmethod
     def axis_polar(cls, lowlat: int = 30, hem: str='N'):
@@ -51,8 +45,7 @@ class Projections():
             hem: str
                 Hemisphere of polar projection. Can be 'N' or 'S' for
                 northern and southern hemispheres, respectively
-                Default: 'N'
-                
+                Default: 'N'         
         """                    
         
         ax = plt.axes(polar=True)
@@ -74,7 +67,4 @@ class Projections():
         ax.set_xticklabels(['00', '', '06', '', '12', '', '18', ''])
         ax.set_theta_zero_location("S")
         
-        return ax       
-                 
-                 
-                 
+        return ax 

--- a/pydarn/plotting/axis.py
+++ b/pydarn/plotting/axis.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2021 SuperDARN Canada, University of Saskatchewan
+# Author: Daniel Billett
+#
+# Modifications:
+#
+# Disclaimer:
+# pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
+# Everyone is permitted to copy and distribute verbatim copies of this license
+# document, but changing it is not allowed.
+#
+# This version of the GNU Lesser General Public License incorporates the terms
+# and conditions of version 3 of the GNU General Public License,
+# supplemented by the additional permissions listed below.
+"""
+Code which generates axis objects for use in plotting functions
+"""
+
+import datetime as dt
+import matplotlib.pyplot as plt
+import numpy as np
+from typing import List
+import pdb
+
+# Third party libraries
+import aacgmv2
+
+class Projections():
+    """
+        Methods for generating axis objects for use in plotting functions
+        Methods
+        -------
+        axis_polar
+        """
+
+    def __str__(self):
+        return "This class is static class that provides"\
+                " the following methods: \n"\
+                "   - axis_polar()\n"
+
+    @classmethod
+    def axis_polar(cls, ax=None):
+        """
+        Plots a radar's Field Of View (FOV) fan plot for the given data and
+        scan number
+
+        Parameters
+        -----------
+            dmap_data: List[dict]
+                asda
+        """                
+             
+        pdb.set_trace()  
+        
+        
+        return ax       
+                 
+                 
+                 

--- a/pydarn/plotting/axis.py
+++ b/pydarn/plotting/axis.py
@@ -18,21 +18,22 @@ Code which generates axis objects for use in plotting functions
 import matplotlib.pyplot as plt
 import numpy as np
 
+
 class Projections():
     """
         Methods for generating axis objects for use in plotting functions
         Methods
         -------
         axis_polar
-        """
+    """
 
     def __str__(self):
         return "This class is static class that provides"\
                 " the following methods: \n"\
-                "   - axis_polar()\n"\
+                "   - axis_polar()\n"
 
     @classmethod
-    def axis_polar(cls, lowlat: int = 30, hem: str='N'):
+    def axis_polar(cls, lowlat: int = 30, hem: str = 'N'):
         """
         Plots a radar's Field Of View (FOV) fan plot for the given data and
         scan number
@@ -45,9 +46,9 @@ class Projections():
             hem: str
                 Hemisphere of polar projection. Can be 'N' or 'S' for
                 northern and southern hemispheres, respectively
-                Default: 'N'         
-        """                    
-        
+                Default: 'N'
+        """
+
         ax = plt.axes(polar=True)
 
         # Set upper and lower latitude limits (pole and lowlat)
@@ -55,16 +56,17 @@ class Projections():
             ax.set_ylim(90, lowlat)
             ax.set_yticks(np.arange(lowlat, 90, 10))
         else:
-            ax.set_ylim(-90, -abs(lowlat)) # If hem is 'S', lowlat must be negative
+            # If hem is 'S', lowlat must be negative
+            ax.set_ylim(-90, -abs(lowlat))
             ax.set_yticks(np.arange(-abs(lowlat), -90, -10))
-         
-        # Locations of tick marks. Will be customisable in future    
+
+        # Locations of tick marks. Will be customisable in future
         ax.set_xticks([0, np.radians(45), np.radians(90), np.radians(135),
                        np.radians(180), np.radians(225), np.radians(270),
                        np.radians(315)])
-                       
-        # Tick labels will depend on coordinate system               
+
+        # Tick labels will depend on coordinate system
         ax.set_xticklabels(['00', '', '06', '', '12', '', '18', ''])
         ax.set_theta_zero_location("S")
-        
-        return ax 
+
+        return ax

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -54,7 +54,7 @@ class Fan():
                  scan_index: Union[int, dt.datetime] = 1,
                  ranges: List = [0, 75], boundary: bool = True,
                  alpha: int = 0.5, parameter: str = 'v',
-                 lowlat: int = 30, cmap: str = None,
+                 cmap: str = None,
                  groundscatter: bool = False,
                  zmin: int = None, zmax: int = None,
                  colorbar: bool = True,

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -297,7 +297,7 @@ class Fan():
         
         # Get radar beam/gate locations
         beam_corners_aacgm_lats, beam_corners_aacgm_lons = \
-            radar_fov(stid, coords='aacgm', date=date)
+            radar_fov(stid, coords=Coords.AACGM, date=date)
         fan_shape = beam_corners_aacgm_lons.shape
 
         # Work out shift due in MLT

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -163,7 +163,7 @@ class Fan():
         plot_beams = np.where(beam_scan == scan_index)
 
         # Time for coordinate conversion
-        dtime = time2datetime(dmap_data[plot_beams[0][0]])
+        date = time2datetime(dmap_data[plot_beams[0][0]])
 
         # Plot FOV outline
         beam_corners_aacgm_lats, beam_corners_aacgm_lons, thetas, rs, ax = \

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -226,9 +226,9 @@ class Fan():
         return beam_corners_aacgm_lats, beam_corners_aacgm_lons, scan, grndsct
 
     @classmethod
-    def plot_fov(cls, stid: str, date: dt = None, ax=None, lowlat: int = 30, 
-                ranges: List = [0, 75], boundary: bool = True, fov_color: str = None,
-                alpha: int = 0.5):
+    def plot_fov(cls, stid: str, date: dt = None, ax=None, ranges: List = [0, 75],
+                boundary: bool = True, fov_color: str = None, alpha: int = 0.5,
+                **kwargs):
         """
         plots only the field of view (FOV) for a given radar station ID (stid)
 
@@ -244,9 +244,6 @@ class Fan():
             date: datetime object
                 Sets the datetime used to find the coordinates of the FOV
                 Default: Current time
-            lowlat: int
-                Lower AACGM latitude boundary for the polar plot
-                Default: 50
             ranges: list
                 Set to a two element list of the lower and upper ranges to plot
                 Default: [0,75]
@@ -260,6 +257,9 @@ class Fan():
                 alpha controls the transparency of
                 the fov color
                 Default: 0.5
+            kawrgs: key = value
+                Additional keyword arguments to be passed to axis_polar, e.g. lowlat, 
+                hem, etc
 
         Returns
         -------
@@ -291,21 +291,7 @@ class Fan():
         # Setup plot
         # This may screw up references
         if ax is None:
-        
-            ax = Projections.axis_polar()
-            
-            ax = plt.axes(polar=True)
-            if beam_corners_aacgm_lats[0, 0] > 0:
-                ax.set_ylim(90, lowlat)
-                ax.set_yticks(np.arange(lowlat, 90, 10))
-            else:
-                ax.set_ylim(-90, -abs(lowlat))
-                ax.set_yticks(np.arange(-abs(lowlat), -90, -10))
-            ax.set_xticks([0, np.radians(45), np.radians(90), np.radians(135),
-                           np.radians(180), np.radians(225), np.radians(270),
-                           np.radians(315)])
-            ax.set_xticklabels(['00', '', '06', '', '12', '', '18', ''])
-            ax.set_theta_zero_location("S")
+            ax = Projections.axis_polar(**kwargs)
 
         if boundary:
             # left boundary line

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -27,7 +27,8 @@ from typing import List
 # Third party libraries
 import aacgmv2
 
-from pydarn import PyDARNColormaps, build_scan, radar_fov, citing_warning, Projections
+from pydarn import (PyDARNColormaps, build_scan, radar_fov, citing_warning,
+    Projections, SuperDARNRadars)
 
 
 class Fan():
@@ -102,9 +103,9 @@ class Fan():
                 the label that appears next to the colour bar.
                 Requires colorbar to be true
                 Default: ''
-            kawrgs: key = value
-                Additional keyword arguments to be passed to axis_polar, e.g. lowlat, 
-                hem, etc                
+            kwargs: key = value
+                Additional keyword arguments 
+                Current key words used: lowlat - used in axis_polar
         Returns
         -----------
         beam_corners_aacgm_lats
@@ -252,8 +253,8 @@ class Fan():
                 the fov color
                 Default: 0.5
             kawrgs: key = value
-                Additional keyword arguments to be passed to axis_polar, e.g. lowlat, 
-                hem, etc
+                Additional keyword arguments 
+                Current key words used: lowlat - used in axis_polar
 
         Returns
         -------
@@ -285,16 +286,8 @@ class Fan():
         # Setup plot
         # This may screw up references
         if ax is None:
-        
-            # If a hemisphere kwarg wasn't passed in, determine the right hemisphere
-            try:
-                kwargs['hem']
-            except:
-                if beam_corners_aacgm_lats[0,0] > 0:
-                    kwargs['hem']='N'
-                else:
-                    kwargs['hem']='S'
-        
+            # Get the hemisphere to pass to plotting projection
+            kwargs['hem'] = SuperDARNRadars.radars[stid].hemisphere
             # Get a polar projection using any kwarg input
             ax = Projections.axis_polar(**kwargs)
 

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -116,8 +116,8 @@ class Fan():
                 can define it with plt.title
                 default: true
             kwargs: key = value
-                Additional keyword arguments 
-                Current key words used: lowlat - used in axis_polar
+                Additional keyword arguments to be used in projection plotting
+                For possible keywords, see: projections.axis_polar
 
         Returns
         -----------
@@ -287,8 +287,8 @@ class Fan():
                 the fov color
                 Default: 0.5
             kawrgs: key = value
-                Additional keyword arguments 
-                Current key words used: lowlat - used in axis_polar
+                Additional keyword arguments to be used in projection plotting
+                For possible keywords, see: projections.axis_polar
 
         Returns
         -------

--- a/pydarn/utils/radar_pos.py
+++ b/pydarn/utils/radar_pos.py
@@ -5,14 +5,14 @@ This module is used for handling coordinates of a specified radar
 in AACGMv2 or geographic coordinates
 """
 
-import datetime
+import datetime as dt
 import numpy as np
 import os
 
 import aacgmv2
 
 
-def radar_fov(stid: int, coords: str = 'aacgm', date: datetime = None):
+def radar_fov(stid: int, coords: str = 'aacgm', date: dt = None):
     """
     Returning beam/gate coordinates of a specified radar's field-of-view
 
@@ -54,7 +54,7 @@ def radar_fov(stid: int, coords: str = 'aacgm', date: datetime = None):
     # AACGMv2 conversion
     if coords == 'aacgm':
         if not date:
-            date = datetime.datetime.now()
+            date = dt.datetime.now()
 
         # Initialise arrays
         fan_shape = beam_corners_lons.shape

--- a/pydarn/utils/radar_pos.py
+++ b/pydarn/utils/radar_pos.py
@@ -14,7 +14,7 @@ import aacgmv2
 from pydarn import Coords
 
 
-def radar_fov(stid: int, coords: str = Coords.AACGM, date: datetime = None):
+def radar_fov(stid: int, coords: str = Coords.AACGM, date: dt = None):
     """
     Returning beam/gate coordinates of a specified radar's field-of-view
 


### PR DESCRIPTION
# Scope 

Remove the functionality of generating a default polar plot from each individual function which does it, placing it in it's own file called `axis.py`. This houses the polar plotting code `axis_polar`, accepting all normal options as kwargs from functions that call it.

Currently, only `plot_fan` and `plot_fov` benefits from this, but it will soon apply to `plot_grid` and any future "mapping" functions, like convection maps. `axis.py` will be further developed in the future so other types of projections, not just `axis_polar`, will be available. 

Currently, the only keywords which `axis_polar` accepts is `lowlat` and `hem` for the lower latitude boundary of the polar plot and the hemisphere, respectively. If no hemisphere is given, it works it out based on what radar is being plotted. 

## A few other changes
- `dtime` keywords have been standardised as `date`, as they were inconsistent.
- `plot_fov` now defaults to current time if no date is given. It would originally give an error.
- General cleaning up of typos and leftover comments which were no longer correct

## Approval

**Number of approvals:** 2

## Test

Both `plot_fan` and `plot_fov` take in the exact same keywords as they did before, except now they are handled as kwargs:
```python
# Read in data
file = "../pydarntesting/20200923.1001.00.rkn.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

# Plot the FOV of the radar with a lower latitude boundary of 60 degrees AACGM latitude 
beam_corners_aacgm_lats, beam_corners_aacgm_lons, thetas, rs, ax = \
		pydarn.Fan.plot_fov(stid=fitacf_data[0]['stid'], lowlat=60)
```
```python
# Make a similar style fan plot
beam_corners_aacgm_lats, beam_corners_aacgm_lons, scan, grndsct = \
	pydarn.Fan.plot_fan(fitacf_data, lowlat=50)
```
```python
# Generate a polar axis object for the southern hemisphere
ax = pydarn.Projections.axis_polar(lowlat=50, hem='S')
```

