### PR TITLE
EHN: Hemisphere  determination in Fan plots 

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -28,7 +28,8 @@ from typing import List, Union
 import aacgmv2
 
 from pydarn import (PyDARNColormaps, build_scan, radar_fov, citing_warning,
-                    time2datetime, plot_exceptions)
+                    time2datetime, plot_exceptions, SuperDARNRadars,
+                    Hemisphere)
 
 
 class Fan():
@@ -307,7 +308,7 @@ class Fan():
         # This may screw up references
         if ax is None:
             ax = plt.axes(polar=True)
-            if beam_corners_aacgm_lats[0, 0] > 0:
+            if SuperDARNRadars.radars[stid].hemisphere == Hemisphere.North:
                 ax.set_ylim(90, lowlat)
                 ax.set_yticks(np.arange(lowlat, 90, 10))
             else:


### PR DESCRIPTION
# Scope 

This uses `SuperDARNRadars` to determine the hemisphere of the radar. 

## Approval

**Number of approvals:** 1 - changed 1 line

## Test

```  python
import pydarn
from datetime import datetime
import matplotlib.pyplot as plt 

pydarn.Fan.plot_fov(66, datetime(2021, 2, 5, 12, 5), ranges=[0, 75])
#pydarn.Fan.plot_fov(4, datetime(2021, 2, 5, 12, 5), ranges=[0, 75])

plt.show()
```
North
![Figure_2](https://user-images.githubusercontent.com/6520530/117339225-bad9eb00-ae5c-11eb-87bd-d63231743b09.png)

South
![Figure_1](https://user-images.githubusercontent.com/6520530/117339211-b7466400-ae5c-11eb-9355-fe678236cbb1.png)

