### PR TITLE
FIX: Function radar_fov call in plot_fov needed updating to use the new Coords.AACGM

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -28,7 +28,7 @@ from typing import List, Union
 import aacgmv2
 
 from pydarn import (PyDARNColormaps, build_scan, radar_fov, citing_warning,
-                    time2datetime, plot_exceptions)
+                    time2datetime, plot_exceptions, Coords)
 
 
 class Fan():
@@ -290,7 +290,7 @@ class Fan():
         """
         # Get radar beam/gate locations
         beam_corners_aacgm_lats, beam_corners_aacgm_lons = \
-            radar_fov(stid, coords='aacgm', date=dtime)
+            radar_fov(stid, coords=Coords.AACGM, date=dtime)
         fan_shape = beam_corners_aacgm_lons.shape
 
         # Work out shift due in MLT


### PR DESCRIPTION
# Scope 

Fan and FOV plots were plotting in geographic in develop branch, when they should be in AACGM coords. 
This was due to the old way of reading in which coordinate system you wanted (ie. coords = 'aacgm'), this has now been amended to read `coords=Coords.AACGM` and should plot in geomag coords now. 

This can be easily seen in the Inuvik radar plots, as Inuvik only skims the geographic north pole, but covers the geomagnetic north pole: see below diagrams. 

**issue:** NA

## Approval

**Number of approvals:** 1

## Test

```python
#Read in fitACF file
file = "20150305.0601.00.inv.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

#Make the fan plot and show
pydarn.Fan.plot_fan(fitacf_data, scan_index=10, 
            groundscatter=1, colorbar=True, parameter='v', 
            colorbar_label='Velocity',
            zmin=-400, zmax=400, boundary=True)
```
Geomagnetic (correct):
<img width="755" alt="Screen Shot 2021-05-06 at 2 40 27 PM" src="https://user-images.githubusercontent.com/60905856/117368281-8c6e0700-ae80-11eb-8a27-471e39208133.png">

Geographic (wrong):
<img width="777" alt="Screen Shot 2021-05-06 at 2 40 05 PM" src="https://user-images.githubusercontent.com/60905856/117368309-96900580-ae80-11eb-89c4-88638bfd693d.png">


