### PR TITLE
Fix/scan index

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -153,23 +153,22 @@ class Fan():
         if isinstance(scan_index, dt.datetime):
             # loop through dmap_data records, dump a datetime
             # list where scans start
-            scan_datetimes = np.array([dt.datetime(*[record[time_component]
-                                                     for time_component in
-                                                     ['time.yr', 'time.mo',
-                                                      'time.dy', 'time.hr',
-                                                      'time.mt', 'time.sc']])
-                                       for record in dmap_data
-                                       if record['scan'] == 1])
-            # find corresponding scan_index
-            matching_scan_index = np.argwhere(scan_datetimes ==
-                                              scan_index)[..., 0] + 1
+            scan_time = scan_index
+            scan_index = 1
+            found_match = False
+            for rec in dmap_data:
+                rec_time  = time2datetime(rec)
+                if rec['scan'] == 1:
+                    scan_index += 1
+                # Need the abs since you cannot have negative seconds
+                diff_time = abs(scan_time - rec_time)
+                if diff_time.seconds < 1:
+                    found_match = True
+                    break
             # handle datetimes out of bounds
-            if len(matching_scan_index) != 1:
-                raise plot_exceptions.IncorrectDateError(scan_datetimes[0],
-                                                         scan_index)
-            else:
-                scan_index = matching_scan_index
-
+            if found_match == False:
+                raise plot_exceptions.IncorrectDateError(rec_time,
+                                                         scan_time)
         # Locate scan in loaded data
         plot_beams = np.where(beam_scan == scan_index)
 

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -155,7 +155,7 @@ class Fan():
             # loop through dmap_data records, dump a datetime
             # list where scans start
             scan_time = scan_index
-            scan_index = 1
+            scan_index = 0
             found_match = False
             for rec in dmap_data:
                 rec_time  = time2datetime(rec)

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -3,7 +3,8 @@
 #
 # Modifications:
 # 2021-05-07: CJM - Included radar position and labels in plotting
-#   2021-04-01 Shane Coyle added pcolormesh to the code
+# 2021-04-01 Shane Coyle added pcolormesh to the code
+# 2021-05-19 Marina Schmidt - Added scan index with datetimes
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md


### PR DESCRIPTION
# Scope 

While making fan plots found a scan index 

**issue:**  Didn't make one as I just fixed it :p

## Approval

**Number of approvals:** 1

## Test

``` python
import pydarn
from datetime import datetime
import matplotlib.pyplot as plt 

cly_file = 'data/20150308.1400.03.cly.fitacf'
pyk_file = 'data/20150308.1401.00.pyk.fitacf'

pyk_data = pydarn.SuperDARNRead().read_dmap(pyk_file)
cly_data = pydarn.SuperDARNRead().read_dmap(cly_file)

#pydarn.Fan.plot_fan(cly_data, scan_index=datetime(2015, 3, 8, 14, 4),
#                    colorbar=False, fov_color='grey', line_color='blue',
#                    radar_label=True)

pydarn.Fan.plot_fan(pyk_data, scan_index=datetime(2015, 3, 8, 14, 4), 
                    colorbar_label='Velocity [m/s]', fov_color='grey',
                    line_color='red', radar_label=True)

#pydarn.Fan.plot_fov(66, datetime(2015, 3, 8, 15, 0), radar_label=True)
plt.show()
```
![fan_3](https://user-images.githubusercontent.com/6520530/118890075-4c187b00-b8bb-11eb-8c6d-2ea91e316827.png)

If you try on `develop` it will not work and raise an error of incorrect date. 
