### PR TITLE
FIX: ground scatter bug

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -5,7 +5,7 @@
 #
 # Modifications:
 # 2021-05-12 Francis Tholley added gate2grounscatter to range-time plots
-#
+# 2021-06-18 Marina Schmidt (SuperDARN Canada) fixed ground scatter colour bug
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
 # Everyone is permitted to copy and distribute verbatim copies of this license

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -412,7 +412,6 @@ class RTP():
             im2 = ax.pcolormesh(time_axis, y_axis, ground_scatter, lw=0.01,
                            cmap=gs_color, norm=norm, **kwargs)
 
-            #cmap.set_under(groundscatter)
         elif groundscatter:
             ground_scatter = np.ma.masked_where( z_data != -1000000, z_data)
             gs_color = colors.ListedColormap(['grey'])

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -398,10 +398,6 @@ class RTP():
                      'elv': PyDARNColormaps.PYDARN}
             cmap = cmaps[parameter]
 
-        if isinstance(groundscatter, str):
-            cmap.set_under(groundscatter, 1.0)
-        elif groundscatter:
-            cmap.set_under('grey', 1.0)
 
         # set the background color, this needs to happen to avoid
         # the overlapping problem that occurs
@@ -409,6 +405,20 @@ class RTP():
         # plot!
         im = ax.pcolormesh(time_axis, y_axis, z_data, lw=0.01,
                            cmap=cmap, norm=norm, **kwargs)
+
+        if isinstance(groundscatter, str):
+            ground_scatter = np.ma.masked_where( z_data != -1000000, z_data)
+            gs_color = colors.ListedColormap([groundscatter])
+            im2 = ax.pcolormesh(time_axis, y_axis, ground_scatter, lw=0.01,
+                           cmap=gs_color, norm=norm, **kwargs)
+
+            #cmap.set_under(groundscatter)
+        elif groundscatter:
+            ground_scatter = np.ma.masked_where( z_data != -1000000, z_data)
+            gs_color = colors.ListedColormap(['grey'])
+            im2 = ax.pcolormesh(time_axis, y_axis, ground_scatter, lw=0.01,
+                           cmap=gs_color, norm=norm, **kwargs)
+
         # setup some standard axis information
         # Upon request of Daniel Billet and others, I am rounding
         # the time down so the plotting x-axis will show the origin


### PR DESCRIPTION
# Scope 

This bug fixes the over-the-coloring of ground scatter, sadly could not get grey into the plot as a legend but could look at that later. 

**issue:** #170 

## Approval

**Number of approvals:** 1 simple fix

## Test

**matplotlib version**: 3.3.4
**Note testers: please indicate what version of matplotlib you are using**

```
import pydarn
import matplotlib.pyplot as plt 

fitacf_file = './data/20150308.1400.03.cly.fitacf'
fitacf_data = pydarn.SuperDARNRead().read_dmap(fitacf_file)

pydarn.RTP.plot_range_time(fitacf_data, groundscatter=True, background='black', zmin=-200, zmax=200, beam_num=3, parameter='v')

plt.show()
```

`develop`

![develop_plot](https://user-images.githubusercontent.com/6520530/122591843-c8b88980-d020-11eb-9b2b-10441e180071.png)

`fix/groundscatter`

![test_plot](https://user-images.githubusercontent.com/6520530/122591850-ca824d00-d020-11eb-80b0-c6dcd76196af.png)
