### PR TITLE
[FIX] scan_index bug

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -150,7 +150,7 @@ class Fan():
         """
         # Get scan numbers for each record
         beam_scan = build_scan(dmap_data)
-
+        scan_time = None
         if isinstance(scan_index, dt.datetime):
             # loop through dmap_data records, dump a datetime
             # list where scans start
@@ -227,7 +227,7 @@ class Fan():
                 slist=slist[good_data]
                 temp_data=dmap_data[i.astype(int)][parameter][good_data]
                 temp_ground=dmap_data[i.astype(int)]['gflg'][good_data]
-                
+
                 scan[slist, beam] = temp_data
                 grndsct[slist, beam] = temp_ground
             # if there is no slist field this means partial record


### PR DESCRIPTION
# Scope 

Fixed the `scan_time` error by adding in at the top `scan_time=None` such that `scan_index=int` works. 

**issue:** #173 

## Approval

**Number of approvals:** 1 - one line change

## Test

```python
import pydarn
import matplotlib.pyplot as plt 

pyk_file = 'data/20150308.1401.00.pyk.fitacf'

pyk_data = pydarn.SuperDARNRead().read_dmap(pyk_file)

pydarn.Fan.plot_fan(pyk_data, scan_index=2,
                    colorbar_label='Velocity [m/s]',
                    line_color='red', radar_label=True)
```

![Figure_1](https://user-images.githubusercontent.com/6520530/124000492-dced7680-d990-11eb-9d71-8b8dbaaae046.png)



**matplotlib version**: 3.3.4
**Note testers: please indicate what version of matplotlib you are using**

