### PR TITLE
swapped the hemisphere and range gate value for ADW

### DIFF
--- a/pydarn/utils/superdarn_radars.py
+++ b/pydarn/utils/superdarn_radars.py
@@ -358,7 +358,7 @@ class SuperDARNRadars():
                           'University of Alaska Fairbanks', Hemisphere.North,
                           75, read_hdw_file('ade')),
               208: _Radar('Adak Island West', 'University of Alaska Fairbanks',
-                          75, Hemisphere.North, read_hdw_file('adw')),
+                          Hemisphere.North, 75, read_hdw_file('adw')),
               33: _Radar('Blackstone', 'Virginia Tech', Hemisphere.North,
                          100, read_hdw_file('bks')),
               207: _Radar('Christmas Valley East', 'Dartmouth College',


### PR DESCRIPTION
# Scope 

This fixes the Hemisphere and range gate value being swapped in `superDARNRadars`, seems like it was the only radar too. 

**issue:** #175 

## Approval

**Number of approvals:** 1 - 1 line change

## Test

**matplotlib version**: 3.8.4
**Note testers: please indicate what version of matplotlib you are using**

``` python
import pydarn
from datetime import datetime
import matplotlib.pyplot as plt 

pydarn.Fan.plot_fov(209, datetime(2021, 2, 5, 12, 5), 
                    radar_label=True, line_color='blue')

pydarn.Fan.plot_fov(208, datetime(2021, 2, 5, 12, 5), 
                    radar_label=True, line_color='green')

plt.show()
```

![Figure_1](https://user-images.githubusercontent.com/6520530/124035296-952f1500-d9b9-11eb-9c70-88687967536b.png)
