### PR TITLE
Pytest/structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,4 @@ install:
     - pip3 install .
     - pip3 install pytest
     - pip3 install pydarnio
-script: pytest --ignore=test/integration 
+script: pytest --ignore=test/data

--- a/test/test_Fan.py
+++ b/test/test_Fan.py
@@ -20,7 +20,7 @@ import warnings
 
 import pydarn
 
-with bz2.open('data/test.fitacf.bz2') as fp:
+with bz2.open('test/data/test.fitacf.bz2') as fp:
     fitacf_stream = fp.read()
 data = pydarn.SuperDARNRead(fitacf_stream, True).read_fitacf()
 

--- a/test/test_Grid.py
+++ b/test/test_Grid.py
@@ -20,7 +20,7 @@ import warnings
 
 import pydarn
 
-data = pydarn.SuperDARNRead('data/test.grid').read_grid()
+data = pydarn.SuperDARNRead('test/data/test.grid').read_grid()
 
 
 class TestGrid_defaults:

--- a/test/test_RTP.py
+++ b/test/test_RTP.py
@@ -20,7 +20,7 @@ import warnings
 
 import pydarn
 
-with bz2.open('data/test.fitacf.bz2') as fp:
+with bz2.open('test/data/test.fitacf.bz2') as fp:
     fitacf_stream = fp.read()
 data = pydarn.SuperDARNRead(fitacf_stream, True).read_fitacf()
 


### PR DESCRIPTION
# Scope 

This PR focuses on the ability to call it from the main pydarn directory which is why travis does

**issue:** #179 

## Approval

**Number of approvals:** 1 - simple change

## Test

**matplotlib version**: 3.3.4
**Note testers: please indicate what version of matplotlib you are using**

```
cd pydarn
pytest --ignore=test/data
```
