### PR TITLE
EHN: Grid key word in FOV to plot the grid of gates and beams

### DIFF
--- a/docs/user/fov.md
+++ b/docs/user/fov.md
@@ -35,6 +35,7 @@ Here is a list of all the current options than can be used with `plot_fov`
 | fov_color=(string)      | Sets the fill in color for the fov plot (default: transparency)                                         |
 | line_color=(string)     | Sets the boundary line and radar location dot color (default: black)                                    |
 | alpha=(int)             | Sets the transparency of the fill color (default: 0.5)                                                  |
+| line_alpha=(int)        | Sets the transparency of the boundary and grid lines if shown (default: 0.5)                            |
 | radar_location=(bool)   | Places a dot in the plot representing the radar location (default: True)                                |
 | radar_label=(bool)      | Places the radar 3-letter abbreviation next to the radar location                                       |
 | kwargs **               | Axis Polar settings. See [polar axis](axis.md)                                                          |

--- a/docs/user/fov.md
+++ b/docs/user/fov.md
@@ -31,6 +31,7 @@ Here is a list of all the current options than can be used with `plot_fov`
 | colorbar=(bool)             | Set true to plot a colorbar (default: True)                                                                      |
 | colorbar_label=(string) | Label for the colour bar (requires colorbar to be true)                                                 |
 | boundary=(bool)         | Set false to not show the outline of the radar FOV (default: True)                                      |
+| grid=(bool)             | Set true to show the outline of the range gates inside the FOV (default: False)                         |
 | fov_color=(string)      | Sets the fill in color for the fov plot (default: transparency)                                         |
 | line_color=(string)     | Sets the boundary line and radar location dot color (default: black)                                    |
 | alpha=(int)             | Sets the transparency of the fill color (default: 0.5)                                                  |

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -268,7 +268,8 @@ class Fan():
                  radar_location: bool = True, radar_label: bool = False,
                  line_color: str = 'black',
                  fov_files: bool = False, 
-                 grid: bool = False, **kwargs):
+                 grid: bool = False, 
+                 line_alpha: int = 0.5 , **kwargs):
         """
         plots only the field of view (FOV) for a given radar station ID (stid)
 
@@ -303,6 +304,10 @@ class Fan():
             alpha: int
                 alpha controls the transparency of
                 the fov color
+                Default: 0.5
+            line_alpha: int
+                line_alpha controls the transparency of
+                the boundary and grid lines of the fov
                 Default: 0.5
             fov_files: bool
                 boolean determine if the fov should be read by the files
@@ -359,31 +364,36 @@ class Fan():
         if boundary:
             # left boundary line
             plt.plot(thetas[0:ranges[1], 0], rs[0:ranges[1], 0],
-                     color=line_color, linewidth=0.5)
+                     color=line_color, linewidth=0.5,
+                     alpha=line_alpha)
             # top radar arc
             plt.plot(thetas[ranges[1] - 1, 0:thetas.shape[1]],
                      rs[ranges[1] - 1, 0:thetas.shape[1]],
-                     color=line_color, linewidth=0.5)
+                     color=line_color, linewidth=0.5,
+                     alpha=line_alpha)
             # right boundary line
             plt.plot(thetas[0:ranges[1], thetas.shape[1] - 1],
                      rs[0:ranges[1], thetas.shape[1] - 1],
-                     color=line_color, linewidth=0.5)
+                     color=line_color, linewidth=0.5,
+                     alpha=line_alpha)
             # bottom arc
             plt.plot(thetas[0, 0:thetas.shape[1] - 1],
                      rs[0, 0:thetas.shape[1] - 1], color=line_color,
-                     linewidth=0.5)
+                     linewidth=0.5, alpha=line_alpha)
 
         if grid:
             # This plots lines along the beams
             for bm in range(fan_shape[1]):
                 plt.plot(thetas[0:ranges[1], bm - 1],
                         rs[0:ranges[1], bm - 1],
-                        color=line_color, linewidth=0.2)
+                        color=line_color, linewidth=0.2,
+                        alpha=line_alpha)
             # This plots arcs along the gates
             for g in range(ranges[1]):
                 plt.plot(thetas[g-1, 0:thetas.shape[1]],
                         rs[g - 1, 0:thetas.shape[1]],
-                        color=line_color, linewidth=0.2)
+                        color=line_color, linewidth=0.2,
+                        alpha=line_alpha)
 
         if radar_location:
             cls.plot_radar_position(stid, date, line_color, **kwargs)

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -266,7 +266,8 @@ class Fan():
                  fov_color: str = None, alpha: int = 0.5,
                  radar_location: bool = True, radar_label: bool = False,
                  line_color: str = 'black',
-                 fov_files: bool = False, **kwargs):
+                 fov_files: bool = False, 
+                 grid: bool = False, **kwargs):
         """
         plots only the field of view (FOV) for a given radar station ID (stid)
 
@@ -289,6 +290,9 @@ class Fan():
             boundary: bool
                 Set to false to not plot the outline of the FOV
                 Default: True
+            grid: bool
+                Set to false to not plot the grid of gates in the FOV
+                Default: False
             fov_color: str
                 fov color to fill in the boundary
                 default: None
@@ -309,7 +313,7 @@ class Fan():
             radar_label: bool
                 Add a label with the radar abbreviation if True
                 Default: False
-            kawrgs: key = value
+            kwargs: key = value
                 Additional keyword arguments to be used in projection plotting
                 For possible keywords, see: projections.axis_polar
 
@@ -353,7 +357,6 @@ class Fan():
 
         if boundary:
             # left boundary line
-
             plt.plot(thetas[0:ranges[1], 0], rs[0:ranges[1], 0],
                      color=line_color, linewidth=0.5)
             # top radar arc
@@ -368,6 +371,18 @@ class Fan():
             plt.plot(thetas[0, 0:thetas.shape[1] - 1],
                      rs[0, 0:thetas.shape[1] - 1], color=line_color,
                      linewidth=0.5)
+
+        if grid:
+            # This plots lines along the beams
+            for bm in range(fan_shape[1]):
+                plt.plot(thetas[0:ranges[1], bm - 1],
+                        rs[0:ranges[1], bm - 1],
+                        color=line_color, linewidth=0.2)
+            # This plots arcs along the gates
+            for g in range(ranges[1]):
+                plt.plot(thetas[g-1, 0:thetas.shape[1]],
+                        rs[g - 1, 0:thetas.shape[1]],
+                        color=line_color, linewidth=0.2)
 
         if radar_location:
             cls.plot_radar_position(stid, date, line_color, **kwargs)

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -5,6 +5,7 @@
 # 2021-05-07: CJM - Included radar position and labels in plotting
 # 2021-04-01 Shane Coyle added pcolormesh to the code
 # 2021-05-19 Marina Schmidt - Added scan index with datetimes
+# 2021-09-08: CJM - Included individual gate and beam boundary plotting for FOV
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md

--- a/test/test_Fan.py
+++ b/test/test_Fan.py
@@ -47,18 +47,19 @@ class TestFan_defaults:
 @pytest.mark.parametrize('radar_label', [True])
 @pytest.mark.parametrize('line_color', ['red'])
 @pytest.mark.parametrize('date', [dt.datetime(2020, 4, 4, 6, 2)])
+@pytest.mark.parametrize('grid', [True, False])
 class TestFov:
 
-    def test_parameters_range_time(self, stid, ranges, boundary, fov_color,
+    def test_fov_plot(self, stid, ranges, boundary, fov_color,
                                    alpha, radar_location, radar_label,
-                                   line_color, date):
+                                   line_color, date, grid):
         """ this test will give bare minimum input needed for """
         with warnings.catch_warnings(record=True):
             pydarn.Fan.plot_fov(stid=stid, ranges=ranges,
                                 boundary=boundary, fov_color=fov_color,
                                 alpha=alpha,
                                 radar_location=radar_location,
-                                radar_label=radar_label,
+                                radar_label=radar_label, grid=grid,
                                 line_color=line_color, date=date)
         plt.close('all')
 

--- a/test/test_Fan.py
+++ b/test/test_Fan.py
@@ -46,13 +46,14 @@ class TestFan_defaults:
 @pytest.mark.parametrize('radar_location', [False])
 @pytest.mark.parametrize('radar_label', [True])
 @pytest.mark.parametrize('line_color', ['red'])
+@pytest.mark.parametrize('line_alpha', [0.8, 1])
 @pytest.mark.parametrize('date', [dt.datetime(2020, 4, 4, 6, 2)])
 @pytest.mark.parametrize('grid', [True, False])
 class TestFov:
 
     def test_fov_plot(self, stid, ranges, boundary, fov_color,
                                    alpha, radar_location, radar_label,
-                                   line_color, date, grid):
+                                   line_color, date, grid, line_alpha):
         """ this test will give bare minimum input needed for """
         with warnings.catch_warnings(record=True):
             pydarn.Fan.plot_fov(stid=stid, ranges=ranges,
@@ -60,7 +61,8 @@ class TestFov:
                                 alpha=alpha,
                                 radar_location=radar_location,
                                 radar_label=radar_label, grid=grid,
-                                line_color=line_color, date=date)
+                                line_color=line_color, date=date,
+                                line_alpha=line_alpha)
         plt.close('all')
 
 


### PR DESCRIPTION
# Scope 

This PR adds the ability to plot all gate and beam boundaries on a FOV or Fan plot using the key word `grid`.
`grid` is defaulted to False, as it's a lot of lines and can look messy especially when plotting data. I have also set the inner lines to have 0.2 width, this seems to look a bit cleaner than the 0.5 lines because there are so many of them.

**issue:**  no linked issue, but mentioned in closed PR #183 

## Approval

**Number of approvals:** 2 (test and code review)

## Test

**matplotlib version**:  3.4.2
**Note testers: please indicate what version of matplotlib you are using**

pytest was run but not modified, no failures

Example of FOV plotting:
```python
import pydarn
from datetime import datetime
import matplotlib.pyplot as plt 

fanplot=pydarn.Fan.plot_fov(66, datetime(2021, 2, 5, 12, 5), radar_location=True, radar_label=True, lowlat= 50,boundary=True, line_color='red', grid = True)
fanplot1=pydarn.Fan.plot_fov(5, datetime(2021, 2, 5, 12, 5), radar_location=True, radar_label=True,  ax=1, boundary=True, line_color='blue', grid = True)
fanplot2=pydarn.Fan.plot_fov(64, datetime(2021, 2, 5, 12, 5), radar_location=True, radar_label=True,  ax=1, boundary=True, line_color='green', grid = True)
fanplot3=pydarn.Fan.plot_fov(65, datetime(2021, 2, 5, 12, 5), radar_location=True, radar_label=True,  ax=1, boundary=True, line_color='orange', grid = True)
fanplot4=pydarn.Fan.plot_fov(6, datetime(2021, 2, 5, 12, 5), radar_location=True, radar_label=True,  ax=1, boundary=True, grid = True)
plt.show()
```
<img width="670" alt="Screen Shot 2021-09-08 at 1 34 55 PM" src="https://user-images.githubusercontent.com/60905856/132578409-33b6b1c7-fb6c-4b39-9d76-4a82aa4637a6.png">

Example of Fan plotting:
```python
import matplotlib.pyplot as plt
import pydarn
import datetime as dt

#Read in fitACF file
file = "/Users/carley/Documents/data/20150305.0601.00.inv.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

time = dt.datetime(2015,3,5,6,5)
fanplot = pydarn.Fan.plot_fan(fitacf_data, scan_index=time,
                    colorbar_label='Velocity [m/s]',zmin=-2000, zmax=2000, lowlat=50, groundscatter=True, grid=True)            
plt.show()
```
<img width="837" alt="Screen Shot 2021-09-08 at 12 52 02 PM" src="https://user-images.githubusercontent.com/60905856/132578580-5d1b11af-a397-4ac2-9e0c-42e15393ffec.png">


