### PR TITLE
EHN: Channel keyword for Fan plots

### DIFF
--- a/docs/user/fan.md
+++ b/docs/user/fan.md
@@ -1,6 +1,7 @@
 <!--Copyright (C) SuperDARN Canada, University of Saskatchewan 
 Author(s): Daniel Billet 
 Modifications:
+20210922: CJM - included info on new channel option
 
 Disclaimer:
 pyDARN is under the LGPL v3 license found in the root directory LICENSE.md 
@@ -89,7 +90,8 @@ Here is a list of all the current options than can be used with `plot_fan`
 
 | Option                        | Action                                                                                                  |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------- |
-| scan_index=(int or  datetime) | Scan number or datetime, from start of records in file                                                  |
+| scan_index=(int or  datetime) | Scan number or datetime, from start of records in file corresponding to channel if given                |
+| channel=(int or 'all')        | Specify channel number or choose 'all' (default = 'all')                                                |
 | groundscatter=(bool)          | True or false to showing ground scatter as grey                                                         |
 | ranges=(list)                 | Two element list giving the lower and upper ranges to plot, grabs ranges from hardware file (default [] |
 | cmap=matplotlib.cm            | A matplotlib color map object. Will override the pyDARN defaults for chosen parameter                   |
@@ -105,6 +107,11 @@ Here is a list of all the current options than can be used with `plot_fan`
 | radar_label=(bool)            | Places the radar 3-letter abbreviation next to the radar location                                       |
 | kwargs **                     | Axis Polar settings. See [polar axis](axis.md)                                                          |
 
+
+!!! Note
+    For some control programs, the user may need to specify a channel integer as `'all'` will not correctly show the data.
+    In other cases, the user may want to specify the channel and use an integer (N) for the `scan_index`. Be aware that this will show the
+    data for the Nth scan of only the chosen channel, not that of the entire file. 
 
 `plot_fan` can concatenate with other plots including itself, here is an example of plotting two different radars with some of the above parameters:
 

--- a/docs/user/range_time.md
+++ b/docs/user/range_time.md
@@ -92,6 +92,7 @@ To see all the customisation options, check out all the parameters listed in 'rt
 |------------------------------|-------------------------------------------------------------|
 | start_time=(datetime object) | Control the start time of the plot                          |
 | end_time=(datetime object)   | Control the end time of the plot                            |
+| channel=(int or string)      | Choose which channel to plot. Default is 'all'.             |
 | groundscatter=(bool)         | True or false to showing ground scatter as grey             |
 | date_fmt=(string)            | How the x-tick labels look. Default is ('%y/%m/%d\n %H:%M') |
 | zmin=(int)                   | Minimum data value to be plotted                            |

--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -23,6 +23,7 @@ from .exceptions import radar_exceptions
 from .exceptions.warning_formatting import standard_warning_format
 from .exceptions.warning_formatting import only_message_warning_format
 from .exceptions.warning_formatting import citing_warning
+from .exceptions.warning_formatting import partial_record_warning
 
 # importing utils
 from .utils.coordinates import Coords

--- a/pydarn/exceptions/plot_exceptions.py
+++ b/pydarn/exceptions/plot_exceptions.py
@@ -186,9 +186,12 @@ class NoChannelError(Exception):
     This error is raised when the channel specified by user
     does not exist
     """
-    def __init__(self, channel: int):
+    def __init__(self, channel: int, opt_channel: int = None):
         self.channel = channel
-        self.message = "There is no data for channel {channel}"\
-                       .format(channel=self.channel)
+        self.opt_channel = opt_channel
+        self.message = "There is no data for channel {channel},"\
+                       " try channel {opt_channel}."\
+                       .format(channel=self.channel,
+                       opt_channel=self.opt_channel)
         super().__init__(self.message)
         pydarn_log.error(self.message)

--- a/pydarn/exceptions/plot_exceptions.py
+++ b/pydarn/exceptions/plot_exceptions.py
@@ -1,5 +1,9 @@
 # Copyright (C) SuperDARN Canada, University of Saskatchewan
 # Authors: Marina Schmidt
+#
+# Modifications:
+# 20210909: CJM - Added NoChannelError
+#
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
 # Everyone is permitted to copy and distribute verbatim copies of this license
@@ -173,5 +177,18 @@ class OutOfRangeGateError(Exception):
             " between 0 - {max_gate}".format(gate_num=self.gate_num,
                                              param=self.parameter,
                                              max_gate=self.max_range_gate-1)
+        super().__init__(self.message)
+        pydarn_log.error(self.message)
+
+
+class NoChannelError(Exception):
+    """
+    This error is raised when the channel specified by user
+    does not exist
+    """
+    def __init__(self, channel: int):
+        self.channel = channel
+        self.message = "There is no data for channel {channel}"\
+                       .format(channel=self.channel)
         super().__init__(self.message)
         pydarn_log.error(self.message)

--- a/pydarn/exceptions/warning_formatting.py
+++ b/pydarn/exceptions/warning_formatting.py
@@ -19,6 +19,15 @@ def citing_warning():
               " https://pydarn.readthedocs.io/en/master/user/citing/")
 
 
+def partial_record_warning():
+    """
+    prints a warning that the data chosen to be plotted is missing some 
+    keys that may produce a blank/half a plot
+    """
+    warnings.warn("Please be aware that the data chosen to be plotted"
+                  " contains a partial record. As such the plot may"
+                  " be empty or only partially filled.")
+
 def standard_warning_format(message: str, category: str, filename: str,
                             lineno: int, file: str = None,
                             line: int = None) -> str:

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -138,10 +138,12 @@ class Fan():
         """
         # Remove all data from dmap_data that is not in chosen channel
         if channel != 'all':
+            # Get the first channel used in case of no data in given channel
+            opt_channel = dmap_data[0]['channel']
             dmap_data = [rec for rec in dmap_data if rec['channel'] == channel]
             # If no records exist, advise user that the channel is not used
             if not dmap_data:
-                raise plot_exceptions.NoChannelError(channel)
+                raise plot_exceptions.NoChannelError(channel,opt_channel)
         
         try:
             ranges = kwargs['ranges']
@@ -274,7 +276,6 @@ class Fan():
         return beam_corners_aacgm_lats, beam_corners_aacgm_lons, scan, grndsct
 
     @classmethod
-
     def plot_fov(cls, stid: str, date: dt.datetime,
                  ax=None, ranges: List = [], boundary: bool = True,
                  fov_color: str = None, alpha: int = 0.5,

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -77,8 +77,9 @@ class Fan():
                 Default: Generates a polar projection for the user
                 with MLT/latitude labels
             scan_index: int or datetime
-                Scan number from beginning of first record in file
-                or datetime given first record to match the index
+                Scan number starting from the first record in file with 
+                associated channel number or datetime given first record 
+                to match the index
                 Default: 1
             parameter: str
                 Key name indicating which parameter to plot.

--- a/test/test_Fan.py
+++ b/test/test_Fan.py
@@ -71,10 +71,11 @@ class TestFov:
 @pytest.mark.parametrize('zmin', [0])
 @pytest.mark.parametrize('zmax', [100])
 @pytest.mark.parametrize('title', [False])
+@pytest.mark.parametrize('channel', [1,2])
 class TestFan:
 
     def test_fan_plot(self, parameter, cmap, groundscatter, colorbar,
-                      colorbar_label, zmin, zmax, title):
+                      colorbar_label, zmin, zmax, title, channel):
         """
 
         """
@@ -82,4 +83,4 @@ class TestFan:
             pydarn.Fan.plot_fan(data, parameter=parameter, cmap=cmap,
                                 groundscatter=groundscatter, colorbar=colorbar,
                                 colorbar_label=colorbar_label, zmin=zmin, zmax=zmax,
-                                title=title)
+                                title=title, channel=channel)


### PR DESCRIPTION
# Scope 

This PR adds a keyword to the plot_fan method which allows the user to plot data from a single channel.
In addition, an exception has been made for when the user chooses a channel but it doesn't exist. 

A warning has also been made which warns that the data chosen has partial records: this is mainly due to the HAN and PYK radars running channels 1 and 2, but channel 2 only has partial records (CPID: 26999 'dummy channel'). But, the warning itself may be useful elsewhere down the line. 

The default will remain at `channel ='all'` which is the same as the RTP plots, and for the majority of cases 'all' will be fine and nothing will change- especially for the channels which are separated into files anyway. 

The main issue is that if you have files with multiple channel data, it may still try to plot 'all' and get confused and plot partial or no data (like the example in the issue), the only thing I can think of to remove this is to set a warning to say 'there's more than one channel of data in here, take care with interpretation and use the channel keyword if needed'. However, this will need to search all the data read in to see which channels are used, and can considerably slow down fan plotting where this isn't really needed 95% of the time. If you think this is a good idea, I can add in this warning, otherwise the user will just have to figure out that the data has more than one channel in the file and that's why it's looking a bit funky. 

**issue:** close #182 

## Approval

**Number of approvals:** 2

## Test

**matplotlib version**: 3.4.2
**Note testers: please indicate what version of matplotlib you are using**
This will return a plot of the channel 1 data:
```python
import matplotlib.pyplot as plt
import pydarn
import datetime as dt

file = "/Users/carley/Documents/data/20141218.0801.00.han.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

time = dt.datetime(2014,12,18,8,24)

fanplot = pydarn.Fan.plot_fan(fitacf_data, scan_index=time,
                    colorbar_label='Velocity [m/s]', lowlat=50, groundscatter=True, channel=1)            
plt.show()
```
<img width="704" alt="Screen Shot 2021-09-09 at 3 56 35 PM" src="https://user-images.githubusercontent.com/60905856/132767970-badbb599-4949-43ba-b482-c88442d18adb.png">

This will return an empty plot and should show the warning that it's a partial record:
```python
import matplotlib.pyplot as plt
import pydarn
import datetime as dt

file = "/Users/carley/Documents/data/20141218.0801.00.han.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

time = dt.datetime(2014,12,18,8,24)

fanplot = pydarn.Fan.plot_fan(fitacf_data, scan_index=time,
                    colorbar_label='Velocity [m/s]', lowlat=50, groundscatter=True, channel=0)            
plt.show()
```
<img width="641" alt="Screen Shot 2021-09-09 at 3 57 06 PM" src="https://user-images.githubusercontent.com/60905856/132768049-bc405460-bdca-4bdf-9346-42d2648397ea.png">

![Screen Shot 2021-09-09 at 3 57 24 PM](https://user-images.githubusercontent.com/60905856/132768055-801913cf-a2ac-46f4-90e4-fd666dd5adc1.png)

And this will give the exception that the channel doesn't exist:
```python
import matplotlib.pyplot as plt
import pydarn
import datetime as dt

file = "/Users/carley/Documents/data/20141218.0801.00.han.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

time = dt.datetime(2014,12,18,8,24)

fanplot = pydarn.Fan.plot_fan(fitacf_data, scan_index=time,
                    colorbar_label='Velocity [m/s]', lowlat=50, groundscatter=True, channel=0)            
plt.show()
```
![Screen Shot 2021-09-09 at 4 05 37 PM](https://user-images.githubusercontent.com/60905856/132768756-af07d4d0-90d4-4a04-986c-98c7a16bdad8.png)


This will return the original plot that gets confused (channel='all'):
```python
import matplotlib.pyplot as plt
import pydarn
import datetime as dt

file = "/Users/carley/Documents/data/20141218.0801.00.han.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

time = dt.datetime(2014,12,18,8,24)

fanplot = pydarn.Fan.plot_fan(fitacf_data, scan_index=time,
                    colorbar_label='Velocity [m/s]', lowlat=50, groundscatter=True)            
plt.show()
```
<img width="610" alt="Screen Shot 2021-09-09 at 3 58 27 PM" src="https://user-images.githubusercontent.com/60905856/132768162-3fa81041-5943-49e8-8499-1318302377b5.png">


Note! that most radars use 0 as the main channel, but a lot use 1 and 2 if using two channels, so you never know.
The HAN data is just an example, but I've tested on SAS a and b files along with single channel files, please test with whatever you have available to get a rounded picture of it working. 
Pytest ran with no failures, not modified at this time.
