### PR TITLE
Modularization of virtual heights

### DIFF
--- a/pydarn/utils/radar_pos.py
+++ b/pydarn/utils/radar_pos.py
@@ -45,6 +45,8 @@ import aacgmv2
 from pydarn import SuperDARNRadars, gate2slant, Coords
 from pydarn.utils.constants import EARTH_EQUATORIAL_RADIUS, Re, C
 
+from pydarn.utils.virtual_heights_types import VH_types
+from pydarn.utils.virtual_heights import standard_virtual_height, chisham
 
 def radar_fov(stid: int, rsep: int = 45, frang: int = 180,
               ranges: tuple = None, fov_files: bool = False,
@@ -146,7 +148,8 @@ def radar_fov(stid: int, rsep: int = 45, frang: int = 180,
 def geographic_cell_positions(stid: int, beam: int, range_gate: int,
                               rsep: int = 45, frang: int = 180,
                               height: float = None, elv_angle: float = 0.0,
-                              center: bool = True, chisham: bool = False):
+                              center: bool = True, chisham: bool = False,
+                              virtual_height_type: object = VH_types.STANDARD_VIRTUAL_HEIGHT):
     """
     determines the geographic cell position for a given range gate and beam
 
@@ -177,9 +180,9 @@ def geographic_cell_positions(stid: int, beam: int, range_gate: int,
             obtain geographic location of the centre of the range gates
             False obtains the front edge of the range gates.
             default: True
-        chisham: bool
-            use the Gareth Chisham virtual height model
-            default: False
+        virtual_height_type: object
+            use for choosing type of virtual height
+            default: VH_types.STANDARD_VIRTUAL_HEIGHT
 
     returns
     -------
@@ -224,7 +227,7 @@ def geographic_cell_positions(stid: int, beam: int, range_gate: int,
                                np.sin(np.radians(elv_angle)) + slant_range**2)
 
     lat, lon = geocentric_coordinates(radar_lat, radar_lon, slant_range,
-                                      height, psi, boresight, chisham)
+                                      height, psi, boresight, virtual_height_type = virtual_height_type)
 
     # convert back degrees as preferred units to use?
     return np.degrees(lat), np.degrees(lon)
@@ -234,7 +237,7 @@ def geographic_cell_positions(stid: int, beam: int, range_gate: int,
 def geocentric_coordinates(radar_lat: float, radar_lon: float,
                            slant_range: float, cell_height: float,
                            psi: float, boresight: float,
-                           chisham: bool = False):
+                           virtual_height_type: object = VH_types.STANDARD_VIRTUAL_HEIGHT):
     """
     Calculates the geocentric coordinates of gate cell  point,
     using either the standard or Chisham virtual height model.
@@ -253,9 +256,9 @@ def geocentric_coordinates(radar_lat: float, radar_lon: float,
             [rad]
         boresight: float
             boresight of the radar beam [rad]
-        chisham: bool
-            use the virtual height chisham model
-            default: False
+        virtual_height_type: object
+            use for choosing type of virtual height
+            default: VH_types.STANDARD_VIRTUAL_HEIGHT
 
     Returns
     -------
@@ -271,51 +274,12 @@ def geocentric_coordinates(radar_lat: float, radar_lon: float,
     radars – Part 1: A new empirical virtual height model by
     G. Chisham 2008 (https://doi.org/10.5194/angeo-26-823-2008)
     """
-    if chisham:
-        # Model constants
-        A_const = (108.974, 384.416, 1098.28)
-        B_const = (0.0191271, -0.178640, -0.354557)
-        C_const = (6.68283e-5, 1.81405e-4, 9.39961e-5)
-
-        # determine which region of ionosphere the gate
-        if slant_range < 115:
-            x_height = (slant_range / 115.0) * 112.0
-        elif slant_range < 787.5:
-            x_height = A_const[0] + B_const[0] * slant_range + C_const[0] *\
-                    slant_range**2
-        elif slant_range <= 2137.5:
-            x_height = A_const[1] + B_const[1] * slant_range + C_const[1] *\
-                    slant_range**2
-        else:
-            x_height = A_const[2] + B_const[2] * slant_range + C_const[2] *\
-                    slant_range**2
-    else:
-        """
-        cell_height, slant_range and x_height are in km
-        Default values set in virtual height model described
-        Mapping ionospheric backscatter measured by the SuperDARN HF
-        radars – Part 1: A new empirical virtual height model by
-        G. Chisham 2008
-        Equation (1) in the paper
-        < 150 km climbing into the E region
-        150 - 600 km E region scatter
-        (Note in the paper 400 km is the edge of the E region)
-        600 - 800 km is F region
-        """
-        # TODO: why 115?
-        # map everything into the E region
-        if cell_height <= 150 and slant_range > 150:
-            x_height = cell_height
-        # virtual height equation (1) from the above paper
-        elif slant_range < 150:
-            x_height = (slant_range / 150.0) * 115
-        elif slant_range >= 150 and slant_range <= 600:
-            x_height = 115
-        elif slant_range > 600 and slant_range < 800:
-            x_height = (slant_range - 600) / 200 * (cell_height - 115) + 115
-        # higher than 800 km
-        else:
-            x_height = cell_height
+    if virtual_height_type == VH_types.CHISHAM:
+        x_height = chisham(slant_range)
+                 
+    if virtual_height_type == VH_types.STANDARD_VIRTUAL_HEIGHT:
+        x_height = standard_virtual_height(slant_range, cell_height)
+        
     # calculate the radius over the earth underneath
     # the radar and range gate cell
     rlat, rlon, r_radar, delta = geodetic2geocentric(radar_lat, radar_lon)

--- a/pydarn/utils/virtual_heights.py
+++ b/pydarn/utils/virtual_heights.py
@@ -1,7 +1,21 @@
+#  (C) Copyright 2021 SuperDARN Canada, University of Saskatachewan
+#  Author(s): Marina Schmidt
+#
+# This file is part of the pyDARN Library.
+#
+# pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
+# Everyone is permitted to copy and distribute verbatim copies of this license
+# document, but changing it is not allowed.
+#
+# This version of the GNU Lesser General Public License incorporates the terms
+# and conditions of version 3 of the GNU Lesser General Public License,
+# supplemented by the additional permissions listed below.
+#
+# Modifications:
+#  2021-09-15 Francis Tholley moved the chisham and standard virtual heigh models to separate file for better encapsulation/modularity
 """ virtual_heights.py comprises of different types of virtual heights"""
 
 def chisham(slant_range: float):
-    # Gareth Chisham Virtual height model:
     """
     Mapping ionospheric backscatter measured by the SuperDARN HF
     radars – Part 1: A new empirical virtual height model by

--- a/pydarn/utils/virtual_heights.py
+++ b/pydarn/utils/virtual_heights.py
@@ -1,0 +1,56 @@
+""" virtual_heights.py comprises of different types of virtual heights"""
+
+def chisham(slant_range: float):
+    # Gareth Chisham Virtual height model:
+    """
+    Mapping ionospheric backscatter measured by the SuperDARN HF
+    radars – Part 1: A new empirical virtual height model by
+    G. Chisham 2008 (https://doi.org/10.5194/angeo-26-823-2008)
+    """
+    # Model constants
+    A_const = (108.974, 384.416, 1098.28)
+    B_const = (0.0191271, -0.178640, -0.354557)
+    C_const = (6.68283e-5, 1.81405e-4, 9.39961e-5)
+
+    # determine which region of ionosphere the gate
+    if slant_range < 115:
+        return (slant_range / 115.0) * 112.0
+    elif slant_range < 787.5:
+        return A_const[0] + B_const[0] * slant_range + C_const[0] *\
+                 slant_range**2
+    elif slant_range <= 2137.5:
+        return A_const[1] + B_const[1] * slant_range + C_const[1] *\
+                 slant_range**2
+    else:
+        return A_const[2] + B_const[2] * slant_range + C_const[2] *\
+                 slant_range**2
+                 
+                 
+def standard_virtual_height(slant_range: float, cell_height: float):
+    """
+    cell_height, slant_range and x_height are in km
+    Default values set in virtual height model described
+    Mapping ionospheric backscatter measured by the SuperDARN HF
+    radars – Part 1: A new empirical virtual height model by
+    G. Chisham 2008
+    Equation (1) in the paper
+    < 150 km climbing into the E region
+    150 - 600 km E region scatter
+    (Note in the paper 400 km is the edge of the E region)
+    600 - 800 km is F region
+    """
+    # TODO: why 115?
+    # map everything into the E region
+    if cell_height <= 150 and slant_range > 150:
+        return cell_height
+    # virtual height equation (1) from the above paper
+    elif slant_range < 150:
+        return (slant_range / 150.0) * 115
+    elif slant_range >= 150 and slant_range <= 600:
+        return 115
+    elif slant_range > 600 and slant_range < 800:
+        return (slant_range - 600) / 200 * (cell_height - 115) + 115
+    # higher than 800 km
+    else:
+        return cell_height       
+                  

--- a/pydarn/utils/virtual_heights_types.py
+++ b/pydarn/utils/virtual_heights_types.py
@@ -1,5 +1,5 @@
-# (C) Copyright 2021 SuperDARN Canada, University of Saskatchewan
-# Author(s): Marina Schmidt
+# (C) Copyright 2021 University of Scranton
+# Author(s): Francis Tholley
 #
 # This file is part of the pyDARN Library.
 #

--- a/pydarn/utils/virtual_heights_types.py
+++ b/pydarn/utils/virtual_heights_types.py
@@ -1,0 +1,34 @@
+# (C) Copyright 2021 SuperDARN Canada, University of Saskatchewan
+# Author(s): Marina Schmidt
+#
+# This file is part of the pyDARN Library.
+#
+# pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
+# Everyone is permitted to copy and distribute verbatim copies of this license
+# document, but changing it is not allowed.
+#
+# This version of the GNU Lesser General Public License incorporates the terms
+# and conditions of version 3 of the GNU Lesser General Public License,
+# supplemented by the additional permissions listed below.
+#
+# Modifications:
+#
+
+"""
+virtual_heights_types.py is a group of methods that focus on the type of virtual heights
+"""
+import enum
+
+class VH_types(enum.Enum):
+    """
+    This virtual height types class is to list the current virtual height systems
+    a user can pick from
+
+    enumerators:
+        STANDARD_VIRTUAL_HEIGHT: Standard_Virtual_height (km)
+        CHISHAM: chisham (km)
+    """
+
+    STANDARD_VIRTUAL_HEIGHT = enum.auto()
+    CHISHAM = enum.auto()
+   


### PR DESCRIPTION
# Scope 

This pull request enables pydarn with the modularization of virtual heights which include the standard virtual height and chisham virtual height. A new empirical virtual height model by G. Chisham 2008 (https://angeo.copernicus.org/articles/26/823/2008/)

## Approval

**Number of approvals:** 2

## Test

```from pydarn.utils.virtual_heights_types import VH_types
from pydarn.utils.virtual_heights import standard_virtual_height, chisham

slant_range = 157.5
cell_height = 300

virtual_height_type = VH_types.CHISHAM
if virtual_height_type == VH_types.CHISHAM:
    x_height = chisham(slant_range)
    print(f"Chisham Virtual Height:{x_height}")
    
virtual_height_type = VH_types.STANDARD_VIRTUAL_HEIGHT    
if virtual_height_type == VH_types.STANDARD_VIRTUAL_HEIGHT:
    x_height = standard_virtual_height(slant_range, cell_height)
    print(f"Standard Virtual Height:{x_height}")
```