### PR TITLE
Release v2.2 

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,6 +8,9 @@
             "name": "Schmidt, M.T.",
             "orcid": "0000-0002-3265-977X"
         },
+        {   "affiliation": "University of Scranton",
+            "name":  "Tholley, F."
+        },
         {
             "affiliation": "University of Saskatchewan",
             "name": "Martin, C.J.",
@@ -55,8 +58,5 @@
         {
             "affiliation": "University of Saskatchewan",
             "name": "Roberston, C.R."
-        },
-        {   "affiliation": "University of Scranton",
-            "name":  "Tholley, F."
         }]
 }

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Python data visualization library for the Super Dual Auroral Radar Network (Supe
 ## Version 2.1.1 - Release!
 
 
-pyDARN release v2.1.1 includes the following features:
-- **New** Time-series plots with vector parameters (velocity, SNR, Spectral width, and Elevaion)
-- Bug fix in Fan plots
+pyDARN release v2.2 includes the following features:
+- **New** Radar geographical Field-of-View (FOV) calculations functionality
+- **Deprecation** Removed FOV files for radars geographic beam location
+- **New** pytesting environment for testing pydarn for development
+- **New** FOV grid lines to show range gates
 - Bug fix in Range-time plots with groundscatter
-- Bug fix in Range-time plots with time-shifting
+- Bug fix in Range-time plots with time-shifting 
 
 !!! Warning
     `slant` option in `plot_range-time` and `plot_summary` is deprecated now uses `coords` 

--- a/docs/dev/communication.md
+++ b/docs/dev/communication.md
@@ -1,6 +1,6 @@
 # Communication Guidelines
 
-pyDARN is under the Data Analysis Working Group that has set up guidelines on [communication](https://superdarn.github.io/dawg/documents/communication-guidelines/) to encourage a positive collaborative environment.
+pyDARN is under the Data Analysis Working Group that has set up guidelines on [communication](communication.md) to encourage a positive collaborative environment.
 Please follow these guidelines when commenting and reviewing code on GitHub. 
 
 Also please read workflow documentation on issues and [pull requests](PR.md) to communicate effectively for collaborative work.
@@ -10,4 +10,4 @@ Also please read workflow documentation on issues and [pull requests](PR.md) to 
 If members have a dispute that violates the communication guidelines, and creates a negative environment in the pyDARN community, please follow this procedure to resolve the conflict:
 1. Please try resolve the matter between each member offline.
 2. If the dispute cannot be resolved, or the environment has become toxic and overwhelming, please contact the [lead developer for pyDARN](https://pydarn.readthedocs.io/en/latest/).
-3. If the dispute cannot be resolved, involves the lead developer, or breaches the [DAWG charter](https://superdarn.github.io/dawg/documents/DAWG_Charter/) please contact the [chairs of DAWG](https://superdarn.github.io/dawg/about/).
+3. If the dispute cannot be resolved, involves the lead developer, or breaches the [DVWG charter](https://superdarn.github.io/DVWG/docs/charter/) please contact the [chair of ](https://superdarn.github.io/DVWG/about/).

--- a/docs/dev/issues.md
+++ b/docs/dev/issues.md
@@ -34,7 +34,7 @@ Please only open issues related to pyDARN. Questions on the following topics sho
 - Corrupt or missing RAWACF files: [Data Distribution Working Group (DDWG)](https://github.com/SuperDARN/DDWG)
 - Radar data formats, hardware files and other metadata: [Data Standards Working Group (DSWG)](https://github.com/superdarn/dswg-published-docs)
 - Radar control programs and operating schedules: [Scheduling Working Group (SWG)](http://superdarn.thayer.dartmouth.edu/wg-scd.html)
-- General questions for the Data Analysis Working Group (DAWG) that are not specifically about pyDARN: open an issue on the [internal DAWG Github repo](https://github.com/SuperDARN/dawg) (requires access rights) or email the [DAWG mailing list](mailto:darn-dawg@isee.nagoya-u.ac.jp)
+- General questions for the Data Visualization Working Group (DVWG) that are not specifically about pyDARN: open an issue on the [internal DVWG Github repo](https://github.com/SuperDARN/DVWG) (requires access rights) or email the [DVWG mailing list](mailto:darn-dvwg@isee.nagoya-u.ac.jp)
 
 ## Submit an Issue
 
@@ -49,7 +49,7 @@ To open a new issue, follow these steps from the [pyDARN repository](https://git
     - Assignees: Assign yourself to the issue if you are planning to work on it yourself. Leave blank if you are not planning to work on it.
     - Labels: these are used to categorize and filter issues (examples below). You can have multiple labels. 
     - Projects: Indicate if this issue is part of a [project](projects.md)
-    - Milestone: Please leave this blank. The DAWG chairs will fill in this information later when a timeline emerges (e.g. working towards a new release)
+    - Milestone: Please leave this blank. The DVWG chairs will fill in this information later when a timeline emerges (e.g. working towards a new release)
     - Linked Pull Request: Leave this blank for now. This can be filled out when a pull request that solves this issue is created (see [pull requests](PR.md))
 * Click *Submit new issue*. At this point, everyone who is subscribed to the pyDARN repository will receive an email. Depending on your notification settings, you may receive emails when others comment on the issue. Check your user settings to subscribe or unsubscribe to email notifications.
 
@@ -57,9 +57,9 @@ To open a new issue, follow these steps from the [pyDARN repository](https://git
 ## Following The Issue
 
 Please follow the ongoing conversation about your issue, especially if other developers request more information. 
-If you do not respond for a while, the issue will go **stale** and may be closed. DAWG tries to keep issues open and contact users if their issues have gone stale. 
+If you do not respond for a while, the issue will go **stale** and may be closed. DVWG tries to keep issues open and contact users if their issues have gone stale. 
 
-Please keep in mind that DAWG members have priorities other than pyDARN, and they live in many different time zones, so be patient while waiting for a response. If nobody has responded in 1-2 weeks, it's fine to ask again.
+Please keep in mind that DVWG members have priorities other than pyDARN, and they live in many different time zones, so be patient while waiting for a response. If nobody has responded in 1-2 weeks, it's fine to ask again.
 
 ## Closing Issues
 
@@ -76,10 +76,10 @@ If an issue goes stale (no progress for over 3 months), the pyDARN lead develope
 
 1. Ask about the issue's status in the conversation
 2. Email the user who opened the issue
-3. Request that we discuss the issue in the next DAWG meeting (add label *telecon*), or place it in a project to be re-opened later
+3. Request that we discuss the issue in the next DVWG meeting (add label *telecon*), or place it in a project to be re-opened later
 * Label the issue **stale** until progress can be made on it again
 * Request to close the issue if none of the above steps elicit any information to keep it open
-* DAWG chairs can close **stale** issues
+* DVWG chairs can close **stale** issues
 
 ## Assignees
 
@@ -93,7 +93,7 @@ pyDARN supports the following [labels](https://github.com/SuperDARN/pydarn/label
 | Label             | Definition                                                  |
 | ----------------- | ----------------------------------------------------------- |
 | bug               | Issue is about a potential bug                              |
-| DAWG              | Issue for Data Analysis Working Group                       |
+| DVWG              | Issue for Data Analysis Working Group                       |
 | DDWG              | Issue for Data Distribution Working Group                   |
 | default change    | Default change in one of the methods                        |
 | Deprecation       | Removing legacy code/feature from the codebase              |
@@ -132,5 +132,5 @@ Then click on *Create Label*.
 ## Open-ended Issues 
 
 Sometimes Issues can be open-ended, especially discussion issues. Here are some steps to make progress on the issue and prevent it going **stale**:
-- Label it with *telecon* if needs to be further discussed in a telecon with DAWG members 
+- Label it with *telecon* if needs to be further discussed in a telecon with DVWG members 
 - Once a general idea is established, close the issue and create a project to break it into a defined tasks. Open the first task as an issue, see [projects](projects.md).

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -67,7 +67,7 @@ and to confirm the version number is correct. State why a release is needed and 
 5. Add the following to the PR info: 
     - **Title**: Release pyDARN <version>
     - **Scope**: add information on the main focus of this release
-    - **Include link to readthedocs** on this release (ask for pyDARN lead developer or DAWG Chair to do this)
+    - **Include link to readthedocs** on this release (DVWG Chair to do this)
     - **Changes:** history of what has changed, look at the [milestones closed tasks](https://github.com/SuperDARN/pydarn/milestones?state=open)
     - **Approvals:** 3 (reviews+testing)
     - **Testing:** Using Github Checklists to include what needs to be tested, tested on what kind of data, and operating systems
@@ -90,14 +90,14 @@ and to confirm the version number is correct. State why a release is needed and 
 !!! IMPORTANT
     Do this before the pull request to make it part of the review process 
 
-- Make sure the `.zenodo.json` file is updated to reflect the [DAWG authorship guidelines]() and everyone is okay with the order. Please confirm with additional new members if their name and ORCID iD is correct. 
+- Make sure the `.zenodo.json` file is updated to reflect the [DVWG authorship guidelines]() and everyone is okay with the order. Please confirm with additional new members if their name and ORCID iD is correct. 
 - Update `setup.py` file to have the new version number on the line `version=""`
 - Update `README.md` file to reflect the new changes of the release and version number 
 
 ### Release Checklist
 
 Once the test is complete and at least three approvals are obtained make sure the following steps are performed.  
-The pyDARN lead developer or DAWG chairs should do this step; however, if you request to do it and get approval then go ahead! 
+The pyDARN lead developer or DVWG chair should do this step; however, if you request to do it and get approval then go ahead! 
 
 1. **merge** the release branch in `master` and confirm the above updates are there
 2. [Tag and release the code](https://github.com/SuperDARN/pydarn/releases/new)
@@ -106,7 +106,7 @@ The pyDARN lead developer or DAWG chairs should do this step; however, if you re
 - Release Title: pyDARN v<version number>
 - Description: Header "Version *number* - Release!" then add "pyDARN release v*number* includes the following features:" listing all the new changes to the code. Please see other [releases](https://github.com/SuperDARN/pydarn/releases) to keep with consistency
 - Hit Publish Release!
-- Once a release has been made check on the [pyDARN Zenodo](https://zenodo.org/record/3727269) and look for the version you just released on the right hand side under **Versions**. Please note this may take some time. If this does not work Contact Lead Developer and DAWG Chairs on the matter.
+- Once a release has been made check on the [pyDARN Zenodo](https://zenodo.org/record/3727269) and look for the version you just released on the right hand side under **Versions**. Please note this may take some time. If this does not work Contact Lead Developer and DVWG Chair on the matter.
 - Once the Zenodo DOI is made for the new release, select the DOI markdown tag on the right hand side below **publication date**. Copy the markdown syntax. 
 - `git checkout master` and `git pull origin master`
 - Paste this syntax in `docs/user/citing.md` under DOI's.       
@@ -167,7 +167,7 @@ This step requires the lead developers help as they have access to the pyDARN Py
 
 After the above is done do the following to make sure everything is up to date: 
 
-- Let the DAWG chairs know a pyDARN release has been made to update the DAWG website 
+- Let the DVWG chair know a pyDARN release has been made to update the DVWG website 
 - Email [DARN-users](darn-users@isee.nagoya-u.ac.jp) about the new release of pyDARN 
 - Merge `master` back into `develop`:
         

--- a/docs/dev/team.md
+++ b/docs/dev/team.md
@@ -1,10 +1,9 @@
 # pyDARN Team
 
-pyDARN is an open source code developed by the SuperDARN community for data visualization. The library resides under the [Data Analysis Working Group (DAWG)](https://superdarn.github.io/dawg/) with support and keeping up data analysis software. 
+pyDARN is an open source code developed by the SuperDARN community for data visualization. The library resides under the [Data Visualization Working Group (DVWG)](https://superdarn.github.io/DVWG/) with support and keeping up data analysis software. 
 
 If you wish to join the pyDARN Team please do the following:
 
-1. Email the [lead developer](https://superdarn.github.io/dawg/about/) to be able to contribute to the [pyDARN GitHub Repository](https://github.com/superdarn/pydarn).
-2. Fill out the [DAWG survey](https://docs.google.com/forms/d/e/1FAIpQLScXAupACBEWFQbyq1Y_A9uUPLT-3_nMXdE9RCudscNdzDvcnw/viewform?usp=sf_link) for us to better get to know you and how you would like to contribute.
-3. Sign up for the [DAWG emailing list](https://portal.isee.nagoya-u.ac.jp:8443/mailman/listinfo/darn-dawg) for updates in DAWG and upcoming meetings including pyDARN matters.
+1. Email the [lead developer](https://superdarn.github.io/DVWG/about/) to be able to contribute to the [pyDARN GitHub Repository](https://github.com/superdarn/pydarn).
+3. Sign up for the [DVWG emailing list](https://portal.isee.nagoya-u.ac.jp:8443/mailman/listinfo/darn-dvwg) for updates in DVWG and upcoming meetings including pyDARN matters.
 4. Please read the [developer documentation](https://pydarn.readthedocs.io/en/latest/) to ensure you follow guidelines. 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 setup(
     cmdclass={'install': initialize_submodules, 'develop': update_submodules},
     name="pydarn",
-    version="2.1.1",
+    version="2.2",
     long_description=long_description,
     long_description_content_type='text/markdown',
     description="Data visualization library for SuperDARN data",


### PR DESCRIPTION
# Scope 

This PR focuses on the following changes that will be released in v2.2:
- **New** Radar geographical Field-of-View (FOV) calculations functionality
- **Deprecation** Removed FOV files for radars geographic beam location
- **New** pytesting environment for testing pydarn for development
- **New** FOV grid lines to show range gates
- Bug fix in Range-time plots with groundscatter
- Bug fix in Range-time plots with time-shifting 


**issue:** #191 

## Approval

**Number of approvals:** 3 approvals by **October 25, 2021**
## Tests

**Note testers: please indicate what version of matplotlib you are using**
Testing the following with the noted changes in the above list. 
- [ ] Runs on windows 
- [ ] Runs on linux Ubuntu, Opensuse 
- [ ] Runs on Mac OSx
- [ ] RTP runs properly 
Test the following with `grid=True`
- [ ] FOV runs properly 
- [ ] Fan runs properly 
- [ ] Grid run propeely 
