### PR TITLE
FIX: Summary plot rendering bug

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -391,7 +391,7 @@ class RTP():
                           " options".format(zmax))
         norm = norm(zmin, zmax)
         if isinstance(cmap, str):
-            cmap = colors.Colormap(cmap)
+            cmap = cm.get_cmap(cmap)
         else:
             # need to do this as matplotlib 3.5 will
             # not all direct mutations of the object


### PR DESCRIPTION
# Scope 

This PR is to fix the bug in issue 207. Summary plots and some range time plots were unable to be plotted.
I don't get Rems depreciation warning after making this change, I think that was fixed by the change to line 398 that occurred in the same commit pre-release (but would be good for Rem to re-check?).

**issue:** to close #207 

## Approval

**Number of approvals:** 1/2 (one liner)

## Test

**matplotlib version**: 3.4.3
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt 
import pydarn

#Load in dmap file
file = "/Users/carley/Documents/data/20211102.0000.00.rkn.a.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

a = pydarn.RTP.plot_summary(fitacf_data, beam_num=5, coords=pydarn.Coords.GROUND_SCATTER_MAPPED_RANGE)
#a = pydarn.RTP.plot_time_series(fitacf_data, beam_num=5, date_fmt = '%H%M', round_start=True)
#a = pydarn.RTP.plot_range_time(fitacf_data, beam_num=5, coords=pydarn.Coords.GROUND_SCATTER_MAPPED_RANGE, round_start=True)
plt.show()
```
The outcome should be a summary plot/range time plot/time series plot as expected.

*Reminder, please check your code is:
  - copyrighted (if applicable)
  - Appropriate disclaimer added
  - Modification line filled in (if applicable)*
