### PR TITLE
FIX: Require pydarnio version 1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,5 +74,5 @@ setup(
     include_package_data=True,
     # setup_requires=['pyyaml', 'numpy', 'matplotlib', 'aacgmv2'],
     install_requires=['pyyaml', 'numpy', 'matplotlib>=3.3.4', 'aacgmv2',
-                      'pydarnio'],
+                      'pydarnio>=1.1.0'],
 )


### PR DESCRIPTION
# Scope 

PR to make sure that when you update or install pydarn (or/and already have a version of pydarnio installed) that it will install version pydarnio 1.1.0 or up.

**issue:** to close #209 

## Approval

**Number of approvals:** 2 (one liner but kinda complicated to test?)

## Test

**matplotlib version**: 3.3.4+ (NA)
**Note testers: please indicate what version of matplotlib you are using**

So to test I've been:
1) making a virtual env 
`python3 -m virtualenv venv-testing-pydario-version`
`source venv-testing-pydario-version/bin/activate`

2) Install pydarn branch and dependencies 
`pip3 install git+https://github.com/superdarn/pydarn@BUG/pydarnio-version`

3) Downgrade pydarnio
`pip3 uninstall pydarnio`
`pip3 install pydarnio==1.0.0`

N.B. this will show you an warning `pydarn 2.2 requires pydarnio>=1.1.0, but you have pydarnio 1.0.0 which is incompatible.`
Which is nice, but still lets you downgrade.

4) Check `pip3 list` to see that pydarnio is at version 1.0.0

5) Uninstall pydarn
`pip3 uninstall pydarn`

6) Reinstall branch 
`pip3 install git+https://github.com/superdarn/pydarn@BUG/pydarnio-version`

Read out should read:
```
Installing collected packages: pydarnio, pydarn
  Attempting uninstall: pydarnio
    Found existing installation: pydarnio 1.0.0
    Uninstalling pydarnio-1.0.0:
      Successfully uninstalled pydarnio-1.0.0
Successfully installed pydarn-2.2 pydarnio-1.1.0
```

You can check `pip3 list` again if you want more confirmation. 

I've tried to install from `git clone` and `python3 setup.py install` However I get a ContextualVersionConflict.
This also happens if I downgrade matplotlib and reinstall pydarn too, so I think that's just not a thing you can do using `python3 setup.py install`.

*Reminder, please check your code is:
  - copyrighted (if applicable)
  - Appropriate disclaimer added
  - Modification line filled in (if applicable)*
