### PR TITLE
[EHN] adding version info

### DIFF
--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -13,6 +13,9 @@ module, classes, and functions.
 
 import os
 
+# version file
+from .version import __version__
+
 # Import io for pyDARN
 from .io.superdarn_io import SuperDARNRead
 

--- a/pydarn/version.py
+++ b/pydarn/version.py
@@ -1,0 +1,20 @@
+# (C) Copyright 2021 SuperDARN Canada, University of Saskatchewan
+# Author: Marina Schmidt
+#
+# Disclaimer:
+# pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
+# Everyone is permitted to copy and distribute verbatim copies of this license
+# document, but changing it is not allowed.
+#
+# This version of the GNU Lesser General Public License incorporates the terms
+# and conditions of version 3 of the GNU General Public License,
+# supplemented by the additional permissions listed below.
+#
+# Modifications:
+#
+
+"""
+This file contains the version number of pydarn
+"""
+
+__version__='2.2.1'

--- a/setup.py
+++ b/setup.py
@@ -52,11 +52,12 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+exec(open('pydarn/version.py').read())
 # Setup information
 setup(
     cmdclass={'install': initialize_submodules, 'develop': update_submodules},
     name="pydarn",
-    version="2.2",
+    version=__version__,
     long_description=long_description,
     long_description_content_type='text/markdown',
     description="Data visualization library for SuperDARN data",


### PR DESCRIPTION
# Scope 

Added `version.py` and `__version__` ability to pydarn to allow users to know which version is installed on their systems. 

**issue:** #205 

## Approval

**Number of approvals:** 1 

## Test

```
import pydarn
pydarn.__version__
```
returns 2.2.1 

Also when you install this branch it should refer to the version as 2.2.1 
