### PR TITLE
Ehn/citing warning

### DIFF
--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -53,4 +53,4 @@ from .plotting.grid import Grid
 from .plotting.acf import ACF
 from .plotting.power import Power
 
-citing_wanring()
+citing_warning()

--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -53,3 +53,4 @@ from .plotting.grid import Grid
 from .plotting.acf import ACF
 from .plotting.power import Power
 
+citing_wanring()

--- a/pydarn/exceptions/warning_formatting.py
+++ b/pydarn/exceptions/warning_formatting.py
@@ -12,16 +12,16 @@ def citing_warning():
     prints a citation warning for pyDARN users to remind them to cite
     pyDARN in publications.
     """
-    warnings.warn("Please make sure to cite pyDARN in publications that"
-              " use plots created by pyDARN using DOI:"
-              " https://zenodo.org/record/3727269. Citing information"
-              " for SuperDARN data is found at"
-              " https://pydarn.readthedocs.io/en/master/user/citing/")
-
+    print() # create a newline
+    print("IMPORTANT: Please make sure to cite pyDARN in publications that"
+          " use plots created by pyDARN using DOI:"
+          " https://zenodo.org/record/3727269. Citing information"
+          " for SuperDARN data is found at"
+          " https://pydarn.readthedocs.io/en/master/user/citing/")
 
 def partial_record_warning():
     """
-    prints a warning that the data chosen to be plotted is missing some 
+    prints a warning that the data chosen to be plotted is missing some
     keys that may produce a blank/half a plot
     """
     warnings.warn("Please be aware that the data chosen to be plotted"

--- a/pydarn/plotting/acf.py
+++ b/pydarn/plotting/acf.py
@@ -14,7 +14,7 @@ from typing import List
 
 from pydarn import (plot_exceptions, SuperDARNRadars,
                     standard_warning_format, time2datetime,
-                    check_data_type, citing_warning)
+                    check_data_type)
 
 warnings.formatwarning = standard_warning_format
 
@@ -258,7 +258,6 @@ class ACF():
                           date=time.strftime("%Y %b %d %H:%M"),
                           cpid=record['cp'])
         ax.set_title(title)
-        citing_warning()
 
     @classmethod
     def __found_scan(cls, scan_num: int, count_num: int,

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -33,9 +33,9 @@ from typing import List, Union
 # Third party libraries
 import aacgmv2
 
-from pydarn import (PyDARNColormaps, build_scan, radar_fov, citing_warning,
+from pydarn import (PyDARNColormaps, build_scan, radar_fov,
                     time2datetime, plot_exceptions, Coords,
-                    SuperDARNRadars, Hemisphere, Projections, 
+                    SuperDARNRadars, Hemisphere, Projections,
                     partial_record_warning)
 
 
@@ -79,8 +79,8 @@ class Fan():
                 Default: Generates a polar projection for the user
                 with MLT/latitude labels
             scan_index: int or datetime
-                Scan number starting from the first record in file with 
-                associated channel number or datetime given first record 
+                Scan number starting from the first record in file with
+                associated channel number or datetime given first record
                 to match the index
                 Default: 1
             parameter: str
@@ -147,7 +147,7 @@ class Fan():
             # If no records exist, advise user that the channel is not used
             if not dmap_data:
                 raise plot_exceptions.NoChannelError(channel,opt_channel)
-        
+
         try:
             ranges = kwargs['ranges']
         except KeyError:
@@ -176,7 +176,7 @@ class Fan():
                                                          scan_time)
         # Locate scan in loaded data
         plot_beams = np.where(beam_scan == scan_index)
-        
+
         # Time for coordinate conversion
         if not scan_time:
         	date = time2datetime(dmap_data[plot_beams[0][0]])
@@ -275,7 +275,6 @@ class Fan():
             end_time = time2datetime(dmap_data[plot_beams[-1][-1]])
             title = cls.__add_title__(start_time, end_time)
             plt.title(title)
-        citing_warning()
         return beam_corners_aacgm_lats, beam_corners_aacgm_lons, scan, grndsct
 
     @classmethod
@@ -284,7 +283,7 @@ class Fan():
                  fov_color: str = None, alpha: int = 0.5,
                  radar_location: bool = True, radar_label: bool = False,
                  line_color: str = 'black',
-                 grid: bool = False, 
+                 grid: bool = False,
                  line_alpha: int = 0.5 , **kwargs):
         """
         plots only the field of view (FOV) for a given radar station ID (stid)
@@ -425,7 +424,6 @@ class Fan():
             r = np.append(r, np.flip(rs[0:ranges[1], thetas.shape[1]-1]))
             r = np.append(r, np.flip(rs[0, 0:thetas.shape[1]-1]))
             ax.fill(theta, r, color=fov_color, alpha=alpha, zorder=0)
-        citing_warning()
         return beam_corners_aacgm_lats, beam_corners_aacgm_lons, thetas, rs, ax
 
     @classmethod

--- a/pydarn/plotting/grid.py
+++ b/pydarn/plotting/grid.py
@@ -28,7 +28,7 @@ from typing import List
 # Third party libraries
 import aacgmv2
 
-from pydarn import (PyDARNColormaps, Fan, plot_exceptions, citing_warning,
+from pydarn import (PyDARNColormaps, Fan, plot_exceptions,
     standard_warning_format)
 
 warnings.formatwarning = standard_warning_format
@@ -276,5 +276,4 @@ class Grid():
         plt.title(title)
         if parameter == 'vector.vel.median':
             return thetas, end_thetas, rs, end_rs, data, azm_v
-        citing_warning()
         return thetas, rs, data

--- a/pydarn/plotting/power.py
+++ b/pydarn/plotting/power.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from typing import List
 
-from pydarn import SuperDARNRadars, exceptions, RTP, citing_warning
+from pydarn import SuperDARNRadars, exceptions, RTP
 
 
 class Power():
@@ -332,5 +332,4 @@ class Power():
         for record in records_of_interest:
             stat_pwr = stat_method(record['pwr0'])
             record.update({'pwr0': stat_pwr})
-        citing_warning()
         return records_of_interest

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -34,7 +34,7 @@ from pydarn import (gate2GroundScatter, gate2slant, check_data_type,
                     time2datetime, rtp_exceptions, plot_exceptions,
                     SuperDARNCpids, SuperDARNRadars,
                     standard_warning_format, PyDARNColormaps,
-                    Coords, citing_warning)
+                    Coords)
 
 warnings.formatwarning = standard_warning_format
 
@@ -507,7 +507,6 @@ class RTP():
                                                       norm) from None
         if colorbar_label != '':
             cb.set_label(colorbar_label)
-        citing_warning()
         return im, cb, cmap, x, y, z_data
 
     @classmethod
@@ -797,7 +796,6 @@ class RTP():
         ax.margins(x=0)
         ax.tick_params(axis='y', which='minor')
 
-        citing_warning()
         return lines, x, y
 
     @classmethod
@@ -1171,7 +1169,6 @@ class RTP():
                      color='gray', ha='right', va='top',
                      rotation=-38, alpha=0.3)
 
-        citing_warning()
         return fig, axes
 
     @classmethod


### PR DESCRIPTION
# Scope 

This PR focuses on moving the citing warning to the import of pydarn so it doesn't have to be added to every plot and be spammed. 

**issue:** #211 

## Approval

**Number of approvals:** 1

## Test

```
import pydarn
``` 
output:
``` 
resetting environment variable IGRF_COEFFS in python script
resetting environment variable AACGM_v2_DAT_PREFIX in python script
non-default coefficient files may be specified by running aacgmv2.wrapper.set_coeff_path before any other functions

IMPORTANT: Please make sure to cite pyDARN in publications that use plots created by pyDARN using DOI: https://zenodo.org/record/3727269. Citing information for SuperDARN data is found at https://pydarn.readthedocs.io/en/master/user/citing/
```

plotting with a file should not return any user warning:
```
pydarn.Fan.plot_fan(fitacf_data, scan_index=2,
                    colorbar_label='Velocity [m/s]',
                    line_color='red', radar_label=True, grid=True)
```
output
```
resetting environment variable IGRF_COEFFS in python script
resetting environment variable AACGM_v2_DAT_PREFIX in python script
non-default coefficient files may be specified by running aacgmv2.wrapper.set_coeff_path before any other functions

IMPORTANT: Please make sure to cite pyDARN in publications that use plots created by pyDARN using DOI: https://zenodo.org/record/3727269. Citing information for SuperDARN data is found at https://pydarn.readthedocs.io/en/master/user/citing/
```
