### PR TITLE
added axes to plot_fov call in plot_fab

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -8,6 +8,7 @@
 # 2021-09-15 Marina Schmidt - removed fov file options
 # 2021-09-09: CJM - Included a channel option for plot_fan
 # 2021-09-08: CJM - Included individual gate and beam boundary plotting for FOV
+# 2021-11-22: MTS - pass in axes object to plot_fov
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
@@ -35,7 +36,7 @@ import aacgmv2
 
 from pydarn import (PyDARNColormaps, build_scan, radar_fov, citing_warning,
                     time2datetime, plot_exceptions, Coords,
-                    SuperDARNRadars, Hemisphere, Projections, 
+                    SuperDARNRadars, Hemisphere, Projections,
                     partial_record_warning)
 
 
@@ -79,8 +80,8 @@ class Fan():
                 Default: Generates a polar projection for the user
                 with MLT/latitude labels
             scan_index: int or datetime
-                Scan number starting from the first record in file with 
-                associated channel number or datetime given first record 
+                Scan number starting from the first record in file with
+                associated channel number or datetime given first record
                 to match the index
                 Default: 1
             parameter: str
@@ -147,7 +148,7 @@ class Fan():
             # If no records exist, advise user that the channel is not used
             if not dmap_data:
                 raise plot_exceptions.NoChannelError(channel,opt_channel)
-        
+
         try:
             ranges = kwargs['ranges']
         except KeyError:
@@ -176,7 +177,7 @@ class Fan():
                                                          scan_time)
         # Locate scan in loaded data
         plot_beams = np.where(beam_scan == scan_index)
-        
+
         # Time for coordinate conversion
         if not scan_time:
         	date = time2datetime(dmap_data[plot_beams[0][0]])
@@ -188,7 +189,7 @@ class Fan():
             ranges = [0, dmap_data[0]['nrang']]
 
         beam_corners_aacgm_lats, beam_corners_aacgm_lons, thetas, rs, ax = \
-            cls.plot_fov(dmap_data[0]['stid'], date, **kwargs)
+            cls.plot_fov(dmap_data[0]['stid'], date, ax=ax, **kwargs)
 
         fan_shape = beam_corners_aacgm_lons.shape
 
@@ -284,7 +285,7 @@ class Fan():
                  fov_color: str = None, alpha: int = 0.5,
                  radar_location: bool = True, radar_label: bool = False,
                  line_color: str = 'black',
-                 grid: bool = False, 
+                 grid: bool = False,
                  line_alpha: int = 0.5 , **kwargs):
         """
         plots only the field of view (FOV) for a given radar station ID (stid)


### PR DESCRIPTION
# Scope 

Fixes the axes bug in `plot_fan` found by @ellioday

**issue:** #215 

## Approval

**Number of approvals:** 1 - test simple fix 

## Test

**matplotlib version**: 3.3.4
**Note testers: please indicate what version of matplotlib you are using**

``` python
import pydarn
from datetime import datetime
import matplotlib.pyplot as plt 
import numpy as np

rkn_file = 'data/20180101.0000.01.rkn.fitacf'
fitacf_data = pydarn.SuperDARNRead().read_dmap(rkn_file)

fig = plt.figure(figsize=[6, 6]) 
ax = fig.add_gridspec(4, 20) 
ax1 = fig.add_subplot(ax[0:3,0:17], polar=True)
ax1.set_ylim(90, 40) 
ax1.set_xticks([0, np.radians(45), np.radians(90), np.radians(135),
                                        np.radians(180), np.radians(225), np.radians(270),
                                        np.radians(315), np.radians(360)])
ax1.set_xticklabels(['00', '03', '06', '09', '12', '15', '18', '21', '00'])
ax1.set_theta_zero_location("S")
ax1.set_yticks(np.arange(40, 90, 10))
ax1.set_thetamin(290-50)
ax1.set_thetamax(290+50)

pydarn.Fan.plot_fan(fitacf_data, scan_index=2,
                    ax=ax1, colorbar_label='Velocity [m/s]',
                    line_color='red', radar_label=True, grid=True)
```

output (ignore the overlap on title and the axes):

![plot_fan_fix](https://user-images.githubusercontent.com/6520530/142884491-7f6552d4-0dc7-462e-8964-633f8460f68d.png)

