### PR TITLE
FIX: Misrepresentation of 15km data/Including frang and rsep in plot_fov call

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -192,6 +192,8 @@ class Fan():
                 ranges = [0,75]
         
         # Get rsep and frang from data unless not there then take defaults
+        # of 180 km for frang and 45 km for rsep as these are most commonly
+        # used
         try:
             frang = dmap_data[0]['frang']
         except KeyError:

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -61,7 +61,7 @@ class Fan():
                 "   - plot_fov()\n"
 
     @classmethod
-    def plot_fan(cls, dmap_data: List[dict], ax=None,
+    def plot_fan(cls, dmap_data: List[dict], ax=None, ranges: List = [],
                  scan_index: Union[int, dt.datetime] = 1,
                  parameter: str = 'v', cmap: str = None,
                  groundscatter: bool = False, zmin: int = None,
@@ -183,10 +183,7 @@ class Fan():
         	date = scan_time
 
         # Plot FOV outline
-        try:
-            # Ranges given in call to function
-            ranges = kwargs['ranges']
-        except KeyError:
+        if ranges == [] or ranges is None:
             try:
                 # If not given, get ranges from data file
                 ranges = [0, dmap_data[0]['nrang']]

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -9,6 +9,8 @@
 # 2021-09-09: CJM - Included a channel option for plot_fan
 # 2021-09-08: CJM - Included individual gate and beam boundary plotting for FOV
 # 2021-11-22: MTS - pass in axes object to plot_fov
+# 2021-02-02: CJM - Included rsep and frang options in plot_fov
+#                 - Re-arranged logic for ranges option
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
@@ -191,9 +193,17 @@ class Fan():
             except KeyError:
                 # Otherwise, default to [0,75]
                 ranges = [0,75]
-                
-        frang = dmap_data[0]['frang']
-        rsep = dmap_data[0]['rsep']
+        
+        # Get rsep and frang from data unless not there then take defaults
+        try:
+            frang = dmap_data[0]['frang']
+        except KeyError:
+            frang = 180
+        
+        try:
+            rsep = dmap_data[0]['rsep']
+        except:
+            rsep = 45
 
         beam_corners_aacgm_lats, beam_corners_aacgm_lons, thetas, rs, ax = \
             cls.plot_fov(dmap_data[0]['stid'], date, ranges=ranges, rsep=rsep, 


### PR DESCRIPTION
# Scope 

This PR is to fix the logic for setting ranges in the plot_fan method, the logic now checks if the user has entered it as an option in the call, if not then it grabs the number of ranges from the data file, if the data file is incomplete then it takes a default [0,75]. 
Rsep and frang should not be changed from default or from data read in as it invalidates the data so these are not keyword options for plot_fan method.

To fix the rsep and frang issues, they're already included in radar_fov, but are not used when called from plot_fov. So I've included them as keywords in plot_fov and when called from plot_fan will automatically plot the fov given by the rsep, frang and nrang in data (if ranges are not specified). You can effectively set the rsep and frang to anything you want in a call to plot_fov, but defaults are 45 and 180 respectively, and defaults or values from data files are used when called from plot_fan.
I'm not 100% sure we need the try loops around the rsep and frang setting in plot_fan but better safe than sorry at this point.

Grid files do not contain the rsep and nrang values of the contributing radars, as such no changes are made to grid plotting with fov. It uses the defaults.

**issue:** to close #218 

## Approval

**Number of approvals:** 2 (at least, so we can make sure it works in most situations)

## Test

**matplotlib version**:  3.5.1
**Note testers: please indicate what version of matplotlib you are using**

FOV test:
```python
import pydarn
from datetime import datetime
import matplotlib.pyplot as plt 


fanplot=pydarn.Fan.plot_fov(66, datetime(2021, 2, 5, 12, 5), radar_location=True, radar_label=True, lowlat= 50,boundary=True, line_color='red', grid = True, rsep=15, frang=500, ranges=[0,100])
fanplot1=pydarn.Fan.plot_fov(5, datetime(2021, 2, 5, 12, 5), radar_location=True, radar_label=True,  ax=1, boundary=True, line_color='blue', grid = True, rsep=45, frang=100, ranges=[0,40])
fanplot2=pydarn.Fan.plot_fov(64, datetime(2021, 2, 5, 12, 5), radar_location=True, radar_label=True,  ax=1, boundary=True, line_color='green', grid = True, rsep=15, frang=90, ranges=[0,75])
fanplot3=pydarn.Fan.plot_fov(65, datetime(2021, 2, 5, 12, 5), radar_location=True, radar_label=True,  ax=1, boundary=True, line_color='orange', grid = True)
fanplot4=pydarn.Fan.plot_fov(6, datetime(2021, 2, 5, 12, 5), radar_location=True, radar_label=True,  ax=1, boundary=True, grid = True, line_alpha=1, rsep=45, frang=0, ranges=[0,100])
plt.show()
```
Produces:
<img width="675" alt="Screen Shot 2022-02-02 at 10 49 22 AM" src="https://user-images.githubusercontent.com/60905856/152204372-b1222af0-7c37-4883-8ff3-658511f0bc8b.png">

FAN: 
```python
import matplotlib.pyplot as plt
import pydarn

# 15km data with 255 range gates and 0 frang!
file = '/Users/carley/Documents/data/20210118.1801.00.rkn.fitacf'
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()
pydarn.Fan.plot_fan(fitacf_data, grid=True, scan_index=2, radar_label=True, groundscatter=True, lowlat=60)
plt.show()
```
Produces:
<img width="799" alt="Screen Shot 2022-02-02 at 10 24 21 AM" src="https://user-images.githubusercontent.com/60905856/152204634-b3b9109b-09e4-4c44-a442-669c67bfb807.png">

*Reminder, please check your code is:
  - copyrighted (if applicable)
  - Appropriate disclaimer added
  - Modification line filled in (if applicable)*
