### PR TITLE
Update working group name!

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
     "creators":[
         {
-            "name": "SuperDARN Data Analysis Working Group"
+            "name": "SuperDARN Data Visualization Working Group"
         },
         {
             "affiliation": "University of Saskatchewan",


### PR DESCRIPTION
# Scope 

I noticed that the group author name of pydarn is still listed as _SuperDARN Data Analysis Working Group_. 

This PR changes it to _SuperDARN Data Visualization Working Group_ in the `.zenodo.json` file, which determines how the software citation appears on Zenodo.

## Approval

1

## Test

Just check that I spelled it correctly!