### PR TITLE
Fix/partial grid records

### DIFF
--- a/pydarn/exceptions/plot_exceptions.py
+++ b/pydarn/exceptions/plot_exceptions.py
@@ -3,7 +3,7 @@
 #
 # Modifications:
 # 20210909: CJM - Added NoChannelError
-#
+# 20220308 MTS - Added PartialRecordsError()
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
 # Everyone is permitted to copy and distribute verbatim copies of this license
@@ -19,14 +19,28 @@ import datetime
 pydarn_log = logging.getLogger('pydarn')
 
 
+class PartialRecordsError(Exception):
+    """
+    Error given when a partial record prevents a plotting algorithm to work
+    """
+    def __init__(self, missing_field):
+        self.message = "pyDARN could not plot the following due to the "\
+                "following field {} was missing. This may be due to partial"\
+                "records created in RST (data processing software for"\
+                " SuperDARN)".format(missing_field)
+        super().__init__(self.message)
+        pydarn_log.error(self.message)
+
+
 class CartopyMissingError(Exception):
     """
     Error given when attmpting a cartopy style plot but cartopy isn't installed
     """
     def __init__(self):
         self.message = 'cartopy is independent library that the user must'\
-                'install to use. Please either change'\
-                ' plot styles or install cartopy and dependencies: https://pydarn.readthedocs.io/en/main/user/install/.'
+                'install to use. Please either change '\
+                'plot styles or install cartopy and dependencies: '\
+                'https://pydarn.readthedocs.io/en/main/user/install/.'
         super().__init__(self.message)
         pydarn_log.error(self.message)
 
@@ -37,7 +51,8 @@ class CartopyVersionError(Exception):
     """
     def __init__(self, version):
         self.message = 'cartopy is independent library that the user must'\
-                'install to use. Please insure the version number is >= 0.19. Your current version is: {}'.format(version)
+                'install to use. Please insure the version number is '\
+                '>= 0.19. Your current version is: {}'.format(version)
         super().__init__(self.message)
         pydarn_log.error(self.message)
 
@@ -215,6 +230,6 @@ class NoChannelError(Exception):
         self.message = "There is no data for channel {channel},"\
                        " try channel {opt_channel}."\
                        .format(channel=self.channel,
-                       opt_channel=self.opt_channel)
+                               opt_channel=self.opt_channel)
         super().__init__(self.message)
         pydarn_log.error(self.message)

--- a/pydarn/plotting/grid.py
+++ b/pydarn/plotting/grid.py
@@ -170,8 +170,11 @@ class Grid():
                 _, aacgm_lons, ax, _ =\
                         Fan.plot_fov(stid, date,
                                      ax=ax, **kwargs)
-                data_lons = dmap_data[record]['vector.mlon']
-                data_lats = dmap_data[record]['vector.mlat']
+                try:
+                    data_lons = dmap_data[record]['vector.mlon']
+                    data_lats = dmap_data[record]['vector.mlat']
+                except KeyError:
+                    raise plot_exceptions.PartialRecordsError('vector.mlon')
 
                 # Hold the beam positions
                 shifted_mlts = aacgm_lons[0, 0] - \

--- a/pydarn/plotting/grid.py
+++ b/pydarn/plotting/grid.py
@@ -2,6 +2,7 @@
 # Author: Daniel Billett, Marina Schmidt
 #
 # Modifications:
+#   20220308 MTS added partial record exception
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -2,6 +2,7 @@
 # Author: Marina Schmidt
 # Copyright (C) 2012  VT SuperDARN Lab
 # Modifications:
+#   20220308 MTS added partial records exception
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -32,7 +32,7 @@ import aacgmv2
 
 from pydarn import (PyDARNColormaps, plot_exceptions,
                     standard_warning_format, Re, Hemisphere,
-                    time2datetime, find_record, Fan, MapParams, Projections)
+                    time2datetime, find_record, Fan, MapParams)
 
 warnings.formatwarning = standard_warning_format
 
@@ -157,12 +157,19 @@ class Maps():
             for stid in dmap_data[record]['stid']:
                 _, aacgm_lons, ax, _ =\
                         Fan.plot_fov(stid, date, ax=ax, **kwargs)
+
         if parameter == MapParams.MODEL_VELOCITY:
-            data_lons = dmap_data[record]['model.mlon']
-            data_lats = dmap_data[record]['model.mlat']
+            try:
+                data_lons = dmap_data[record]['model.mlon']
+                data_lats = dmap_data[record]['model.mlat']
+            except KeyError:
+                raise plot_exceptions.PartialRecordsError('model.mlon')
         else:
-            data_lons = dmap_data[record]['vector.mlon']
-            data_lats = dmap_data[record]['vector.mlat']
+            try:
+                data_lons = dmap_data[record]['vector.mlon']
+                data_lats = dmap_data[record]['vector.mlat']
+            except KeyError:
+                raise plot_exceptions.PartialRecordsError('model.mlat')
 
             # Hold the beam positions
             shifted_mlts = aacgm_lons[0, 0] - \


### PR DESCRIPTION
# Scope 

While potentially finding a bug with RST in `make_grid` not processing 2022 data for fitacf 3.0 (it seems). I ran into partial records everywhere in the files so here is a fix for pyDARN end 

Will report the RST issue on RST :p 

**issue:** #236 

## Approval

**Number of approvals:** 1

## Test

If you need partial record data please ask or try out the potential RST bug ;)


**matplotlib version**: 3.5.1

```python
mport pydarn
import matplotlib.pyplot as plt 

grid_file = "../data/grid/20220108.0001.00.hok.grid"
grid_data = pydarn.SuperDARNRead(grid_file).read_grid()

pydarn.Grid.plot_grid(grid_data, record=5, fov_color='grey')
plt.show()
```

``` bash
resetting environment variable IGRF_COEFFS in python script
resetting environment variable AACGM_v2_DAT_PREFIX in python script
non-default coefficient files may be specified by running aacgmv2.wrapper.set_coeff_path before any other functions

IMPORTANT: Please make sure to cite pyDARN in publications that use plots created by pyDARN using DOI: https://zenodo.org/record/3727269. Citing information for SuperDARN data is found at https://pydarn.readthedocs.io/en/master/user/citing/
pyDARN could not plot the following due to the following field vector.mlon was missing. This may be due to partialrecords created in RST (data processing software for SuperDARN)
Traceback (most recent call last):
  File "/home/marina/.local/lib/python3.8/site-packages/pydarn/plotting/grid.py", line 174, in plot_grid
    data_lons = dmap_data[record]['vector.mlon']
KeyError: 'vector.mlon'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test_grid.py", line 13, in <module>
    pydarn.Grid.plot_grid(grid_data, record=5, fov_color='grey')
  File "/home/marina/.local/lib/python3.8/site-packages/pydarn/plotting/grid.py", line 177, in plot_grid
    raise plot_exceptions.PartialRecordsError('vector.mlon')
pydarn.exceptions.plot_exceptions.PartialRecordsError: pyDARN could not plot the following due to the following field vector.mlon was missing. This may be due to partialrecords created in RST (data processing software for SuperDARN)

```
