### PR TITLE
Ehn/grid lines cartopy

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -329,7 +329,7 @@ class Fan():
             end_time = time2datetime(dmap_data[plot_beams[-1][-1]])
             title = cls.__add_title__(start_time, end_time)
             plt.title(title)
-        return beam_corners_lats, beam_corners_lons, scan, grndsct
+        return ax, beam_corners_lats, beam_corners_lons, scan, grndsct
 
     @classmethod
     def plot_fov(cls, stid: str, date: dt.datetime,

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -34,7 +34,7 @@ except Exception:
 
 
 def axis_polar(lowlat: int = 30, hemisphere: Hemisphere = Hemisphere.North,
-               **kwargs):
+               grid_lines: bool = True, **kwargs):
     """
     Plots a radar's Field Of View (FOV) fan plot for the given data and
     scan number
@@ -76,7 +76,7 @@ def axis_polar(lowlat: int = 30, hemisphere: Hemisphere = Hemisphere.North,
 
 def axis_geological(date, ax: object = None,
                     hemisphere: Hemisphere = Hemisphere.North,
-                    lowlat: int = 30, **kwargs):
+                    lowlat: int = 30, grid_lines: bool = True, **kwargs):
     """
     """
     if cartopyInstalled is False:
@@ -90,16 +90,16 @@ def axis_geological(date, ax: object = None,
     if hemisphere == Hemisphere.North:
         pole_lat = 90
         noon = -deg_from_midnight
-        # ylocations = -5
+        ylocations = -5
     else:
         pole_lat = -90
         noon = 360 - deg_from_midnight
-        # ylocations = 5
+        ylocations = 5
     # handle none types or wrongly built axes
     proj = ccrs.Orthographic(noon, pole_lat)
     ax = plt.subplot(111, projection=proj, aspect='auto')
-    ax.coastlines()
-    # ax.gridlines(ylocs=np.arange(pole_lat, 0, ylocations))
+    if grid_lines:
+        ax.gridlines(draw_labels=True)
 
     extent = min(45e5,
                  (abs(proj.transform_point(noon, lowlat,

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -2,7 +2,8 @@
 # Author: Daniel Billett
 #
 # Modifications:
-#
+# 2022-03-11 MTS added enums for projection function calls
+# 2022-03-22 MTS removed coastline call and added grid lines to cartopy plotting
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
 # Everyone is permitted to copy and distribute verbatim copies of this license


### PR DESCRIPTION
# Scope 

This PR added `grid_lines` option into `Projs.GEO` into. Also I removed coastaline as user can call that afterwards like other cartopy features for coloring in land and ocean instead of pyDARN having a bunch of parameters for that. 

**issue:** #244 

## Approval
**Number of approvals:** 1 approval very simple change 

This PR should wait until #242 is merged since it branches off that 

## Test

**matplotlib version**: 3.5.1
**Note testers: please indicate what version of matplotlib you are using** 

*provide a list or code to test*

``` python
import matplotlib.pyplot as plt 

data_file = "/home/marina/superdarn/data/fitacf/20220108.1201.00.dcn.fitacf.bz2" 
with bz2.open(data_file) as fp: 
    fitacf_stream = fp.read()

data = pydarn.SuperDARNRead(fitacf_stream, True).read_fitacf()

ax, _, _, _, _ = pydarn.Fan.plot_fan(data, grid_lines=False, scan_index=5, radar_label=True, groundscatter=True, coords=pydarn.Coords.GEOGRAPHIC, projs=pydarn.Projs.GEO, colorbar_label="Velocity m/s")
ax.coastlines()
plt.show()
```
![south_geo](https://user-images.githubusercontent.com/6520530/159549278-2343dcae-a549-4cde-a780-735cd7fda7e9.png)

Rankin Inlet Data
![Figure_1](https://user-images.githubusercontent.com/6520530/159549296-110920a2-2f0e-4360-b564-db8236487372.png)



*Reminder, please check your code is:
  - copyrighted (if applicable)
  - Appropriate disclaimer added
  - Modification line filled in (if applicable)*
