### PR TITLE
Ehn/error aacgm geo

### DIFF
--- a/docs/user/coordinates.md
+++ b/docs/user/coordinates.md
@@ -15,9 +15,9 @@ the additional permissions listed below.
 # Coordinate Systems 
 ---
 
-pyDARN offers several different measurement systems for various type of plotting: 
-- Range Estimation: the estimate of how far the target (echo) to the radar
-- Coordinates systems: Generic geographic coordinate systems with conversions to AACGM and AACGM MLT 
+pyDARN offers several different measurement systems for various types of plotting: 
+- Range Estimation: the estimate of how far the target (echo) is from the radar
+- Coordinate systems: Generic geographic coordinate system with conversions to AACGM and AACGM MLT 
 
 ## Range-Time Plots 
 
@@ -48,9 +48,9 @@ Geographic plots include: fan, grid and convection map (coming soon) plots
 
 **AACGM**: `Coords.AACGM` is [Altitude Adjusted Corrected Geogmagnetic Coordinates developed by Dr. Simon Shepherd](http://superdarn.thayer.dartmouth.edu/aacgm.html) are an extension of corrected geomagnetic (CGM) coordinates that more accurately represent the actual magnetic field. In AACGM coordinates points along a given magnetic field line are given the same coordinates and thus are a better reflection of magnetic conjugacy. pyDARN uses AACGM-V2 from the [aacgmv2 python library](https://pypi.org/project/aacgmv2/). Implemented by Dr. Daniel Billett from University of Saskatchewan. 
 
-**AACGM_MLT**: `Coords.AACGM_MLT` is `Coords.AACGM` with the longitude shift to line up 
+**AACGM_MLT**: `Coords.AACGM_MLT` is `Coords.AACGM` with the geomagnetic longitude converted to magnetic local time
 
-`RangeEstimation` methods can be used with `Coords` calculation for example, using `Coords.GEOGRAPHIC` using `RangeEstimation.GSMR` to determine the coordinates. 
+`RangeEstimation` methods can be used with a `Coords` calculation. For example, using `Coords.GEOGRAPHIC` and `RangeEstimation.GSMR` together, will give a plot of ionospheric echoes at a distance from the radar calculated in ground scatter mapped range, in geographic coordinates. 
 
 !!! Warning
     You cannot use `RangeEstimation.RANGE_GATES` with any `Coords`, the default is `RangeEstimation.SLANT_RANGE`

--- a/pydarn/exceptions/plot_exceptions.py
+++ b/pydarn/exceptions/plot_exceptions.py
@@ -56,6 +56,14 @@ class CartopyVersionError(Exception):
         super().__init__(self.message)
         pydarn_log.error(self.message)
 
+class NotImplemented(Exception):
+    """
+    Error given when settings are not implemented right now.
+    """
+    def __init__(self, msg):
+        self.message = msg
+        super().__init__(self.message)
+        pydarn_log.error(self.message)
 
 class IncorrectPlotMethodError(Exception):
     """

--- a/pydarn/exceptions/plot_exceptions.py
+++ b/pydarn/exceptions/plot_exceptions.py
@@ -4,6 +4,8 @@
 # Modifications:
 # 20210909: CJM - Added NoChannelError
 # 20220308 MTS - Added PartialRecordsError()
+# 2022-03-23 MTS - Added NotImplementedError() indicates when something is not implement in pyDARN
+#
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
 # Everyone is permitted to copy and distribute verbatim copies of this license

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -208,12 +208,21 @@ class Fan():
             rsep = dmap_data[0]['rsep']
         except KeyError:
             rsep = 45
+
+        if coords != Coords.GEOGRAPHIC and projs == Projs.GEO:
+            raise plot_exceptions.NotImplemented("AACGM coordinates currently"\
+                                                 " is not implemented right"\
+                                                 " now, if you would like to"\
+                                                 " see it sooner please help"\
+                                                 " out on "\
+                                                 "https://github.com"\
+                                                 "/SuperDARN/pyDARN")
+
         beam_corners_lats, beam_corners_lons =\
                 coords(stid=dmap_data[0]['stid'],
                        rsep=rsep, frang=frang,
                        gates=ranges, date=date,
                        **kwargs)
-
 
         fan_shape = beam_corners_lons.shape
         if ranges[0] < ranges[1] - fan_shape[0]:

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -16,8 +16,8 @@
 # 2022-03-10: MTS - switched coords involving range estimations to RangeEstimation
 #                 - Removed GEO_COASTALINE, replaced with GEO on projections
 #                 - reduced some parameters inputs to kwargs
-# 2021-03-22: CJM - Set cmap bad values to transparent
-#
+# 2022-03-22: CJM - Set cmap bad values to transparent
+# 2022-03-23: MTS - added the NotImplementedError for AACGM and GEO projection as this has yet to be figured out
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
 # Everyone is permitted to copy and distribute verbatim copies of this license


### PR DESCRIPTION
# Scope 

This PR handles AACGM and GEO not correctly implemented currently. 
By raising an error that can be usef for other non-implemented features in pyDARN. 

**issue:** 

## Approval

**Number of approvals:** 1 very easy change

Again lets wait for #242 to be merged

## Test

**matplotlib version**: 3.5.1
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt

data_file = "/home/marina/superdarn/data/fitacf/20220108.1201.00.dcn.fitacf.bz2" 
with bz2.open(data_file) as fp:
    fitacf_stream = fp.read()

data = pydarn.SuperDARNRead(fitacf_stream, True).read_fitacf()

pydarn.Fan.plot_fan(data, scan_index=5, radar_label=True, groundscatter=True, coords=pydarn.Coords.AACGM, projs=pydarn.Projs.    GEO, colorbar_label="Velocity m/s")
plt.show()
```

```bash
GEO, colorbar_label="Velocity m/s")
  File "/home/marina/.local/lib/python3.8/site-packages/pydarn/plotting/fan.py", line 213, in plot_fan
    raise plot_exceptions.NotImplemented("AACGM coordinates currently"\
pydarn.exceptions.plot_exceptions.NotImplemented: AACGM coordinates currently is not implemented right now, if you would like to see it sooner please help out on https://github.com/SuperDARN/pyDARN
```


*Reminder, please check your code is:
  - copyrighted (if applicable)
  - Appropriate disclaimer added
  - Modification line filled in (if applicable)*
