### PR TITLE
FIX: Bug where FOV in a fan plot is coloured white

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -230,6 +230,10 @@ class Fan():
 
                     'elv': PyDARNColormaps.PYDARN}
             cmap = plt.cm.get_cmap(cmap[parameter])
+        
+        # Set background to transparent - avoids carry over
+        # does not interfere with the fov color if chosen
+        cmap.set_bad(alpha=0.0)
 
         # Setting zmin and zmax
         defaultzminmax = {'p_l': [0, 50], 'v': [-200, 200],

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -230,7 +230,7 @@ class Fan():
 
                     'elv': PyDARNColormaps.PYDARN}
             cmap = plt.cm.get_cmap(cmap[parameter])
-        
+
         # Set background to transparent - avoids carry over
         # does not interfere with the fov color if chosen
         cmap.set_bad(alpha=0.0)

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -13,6 +13,7 @@
 # 2021-02-02: CJM - Included rsep and frang options in plot_fov
 #                 - Re-arranged logic for ranges option
 #                 - Indexing fixed for give lower ranges that are non-zero
+# 2021-03-22: CJM - Set cmap bad values to transparent
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md


### PR DESCRIPTION
# Scope 

This PR fixes the bug where the FOV appears white in a small number of cases. A line in rtp.py sets bad values of a colormap to be white to fill in the background of the RTP/summary plots. If you plot a RTP and then a fan in the same program you would end up with the white background being carried over from being set in rtp.py. 
Setting the bad value to transparent makes the fan see-through again and doesn't interfere with any of the FOV kwargs as it's just transparent so you can see the FOV below. 

Other than forcing the transparency of the fan plot, is there a better way that we could be dealing with the cmap issue?

To see the difference you can compare this branch with current develop.

**issue:** NA but discussed in #242 

## Approval

**Number of approvals:** 1 (one liner)

## Test

**matplotlib version**:  3.5.1
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt
import pydarn
file='/Users/carley/Documents/data/20150308.1400.03.cly.fitacf'
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

pydarn.Fan.plot_fan(fitacf_data, fov_color='red', scan_index=5,
                    radar_label=True, groundscatter=True,
                    coords=pydarn.Coords.GEOGRAPHIC ,projs=pydarn.Projs.GEO_COASTALINE)
plt.show()

pydarn.RTP.plot_range_time(fitacf_data, beam_num=7, 
                           coords=pydarn.Coords.SLANT_RANGE)
plt.title('North Slant Range RTP')
plt.show()

pydarn.Fan.plot_fan(fitacf_data, grid=True, scan_index=5, radar_label=True, 
                    coords=pydarn.Coords.GROUND_SCATTER_MAPPED_RANGE, 
                    groundscatter=True) 
plt.show()
```
Before fan plot:
<img width="789" alt="Screen Shot 2022-03-22 at 5 13 18 PM" src="https://user-images.githubusercontent.com/60905856/159591444-1521c412-3034-44b2-b1c6-daa9bb181cc1.png">

After fan plot:
<img width="521" alt="Screen Shot 2022-03-22 at 5 13 28 PM" src="https://user-images.githubusercontent.com/60905856/159591458-f44c2e4f-25bd-46b2-ae37-e1b756d26ce1.png">



**Cartopy required for first fan plot - note as this is pulled from develop before #242 was merged, it is the old way of calling coords and projs!*

*Reminder, please check your code is:
  - copyrighted (if applicable)
  - Appropriate disclaimer added
  - Modification line filled in (if applicable)*
