### PR TITLE
EHN: IMF Clock Angle Dial

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -26,6 +26,7 @@ import warnings
 
 from enum import Enum
 from matplotlib import ticker, cm, colors
+from mpl_toolkits.axes_grid.inset_locator import InsetPosition
 from scipy import special
 from typing import List
 
@@ -64,7 +65,8 @@ class Maps():
                      colorbar: bool = True, colorbar_label: str = '',
                      title: str = '', zmin: float = None, zmax: float = None,
                      hmb: bool = True, boundary: bool = False,
-                     radar_location: bool = False, **kwargs):
+                     radar_location: bool = False, imf_dial: bool = True,
+                     **kwargs):
         """
         Plots convection maps data points and vectors
 
@@ -126,6 +128,9 @@ class Maps():
                 Normalisation factor for the vectors, to control size on plot
                 Larger number means smaller vectors on plot
                 Default: 150.0
+            imf_dial: bool
+                If True, draw an IMF dial of the magnetic field clock angle.
+                Default: True
             kwargs: key=value
                 uses the parameters for plot_fov and projections.axis
 
@@ -300,6 +305,16 @@ class Maps():
                               end_minute=str(dmap_data[record]['end.minute']).
                               zfill(2))
         plt.title(title)
+
+        if imf_dial is True:
+            # Plot the IMF dial
+            bx = dmap_data[record]['IMF.Bx']
+            by = dmap_data[record]['IMF.By']
+            bz = dmap_data[record]['IMF.Bz']
+            delay = dmap_data[record]['IMF.delay']
+            bt = np.sqrt(bx**2 + by**2 + bz**2)
+            cls.plot_imf_dial(ax, by, bz, bt, delay)
+
         return mlats, mlons, v_mag
 
 
@@ -548,6 +563,62 @@ class Maps():
 
         """
         plt.plot(mlons, mlats, c=line_color, zorder=4.0, **kwargs)
+
+
+    @classmethod
+    def plot_imf_dial(cls, ax: object, by: float = 0, bz: float = 0,
+                      bt: float = 0, delay: float = 0):
+        """
+        Plots an IMF clock angle dial on the existing plot
+        Defaults all to 0 if no IMF data available to plot
+
+        Parameters
+        ----------
+            ax: object
+                matplotlib axis object
+            by: Float
+                Value of the magnetic field in the y-direction (nT)
+                Default = 0 nT
+            bz: Float
+                Value of the magnetic field in the z-direction (nT)
+                Default = 0 nT
+            bt: Float
+                Magnitude of the magnetic field (nT)
+                Default = 0 nT
+            delay: Float
+                Time delay of magnetic field between the
+                measuring satellite and the ionosphere (minutes)
+                Default = 0 minutes
+        """
+        # Create new axes inside existing axes
+        ax_imf = plt.axes([0, 0, 1, 1])
+        ip = InsetPosition(ax, [-0.2, 0.7, 0.4, 0.4])
+        ax_imf.set_axes_locator(ip)
+        ax_imf.axis('off')
+
+        ax_imf.set_xlim([-20.2, 20.2])
+        ax_imf.set_ylim([-20.2, 20.2])
+
+        # Plot a Circle
+        limit_circle = plt.Circle((0, 0), 10, facecolor='w',
+                                  edgecolor='k')
+        ax_imf.add_patch(limit_circle)
+        # Plot axis lines
+        plt.plot([-10, 10], [0, 0], color='k', linewidth=0.5)
+        plt.plot([0, 0], [-10, 10], color='k', linewidth=0.5)
+
+        # Plot line for magnetic field
+        plt.plot([0, by], [0, bz], color='r')
+
+        # Add axis labels
+        ax_imf.annotate('+Z', xy=(-2.5, 11))
+        ax_imf.annotate('+Y', xy=(11, -1))
+
+        # Add annotations for delay and Btot
+        ax_imf.annotate('|B| = ' + str(round(bt)) + ' nT', xy=(-16, -13),
+                        fontsize=7)
+        ax_imf.annotate('Delay = -' + str(delay) + ' min', xy=(-16, -17),
+                        fontsize=7)
 
 
     @classmethod

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -4,6 +4,7 @@
 # Modifications:
 # 2022-03-08: MTS - added partial records exception
 # 2021-03-18: CJM - Included contour plotting and HMB
+# 2021-03-31: CJM - IMF clock angle dial added
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md


### PR DESCRIPTION
# Scope 

This PR adds the IMF clock angle on to the convection plots. 
There is not much in the way of customising it, but you can turn it off by setting 'imf_dial=False'.
As it is adding an additional axis to the plot, the user should be careful if adding to the plot later, as the gca will give the mini-axes for the dial rather than the larger plot. But I believe that specifying 'ax' will allow you to amend the main plot to your liking - please have a test of this if possible.
The actual axes size is twice the size of the plotted circle to allow for larger imf values to not be cut off - so bear that in mind when reviewing the values in the positioning of the annotations and sizing.

**issue:** to close #251 

## Approval

**Number of approvals:** 2

## Test

**matplotlib version**: 3.5.1
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt
import pydarn
map_file = "/Users/carley/Documents/data/maps/20150310.n.map"
map_data = pydarn.SuperDARNRead().read_dmap(map_file)
pydarn.Maps.plot_mapdata(map_data,record=180, 
            parameter=pydarn.MapParams.FITTED_VELOCITY,
            lowlat=60)
plt.show()
```
Gives:
<img width="793" alt="Screen Shot 2022-03-31 at 12 07 04 PM" src="https://user-images.githubusercontent.com/60905856/161124847-0791e371-6824-44a2-9ae7-78913ba93270.png">
<img width="242" alt="Screen Shot 2022-03-31 at 12 07 12 PM" src="https://user-images.githubusercontent.com/60905856/161124867-3d21403f-ca2d-4369-ab81-a1359347f687.png">


*Reminder, please check your code is:
  - copyrighted (if applicable)
  - Appropriate disclaimer added
  - Modification line filled in (if applicable)*
