### PR TITLE
EHN: Map Info on Convection Maps

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -4,6 +4,7 @@
 # Modifications:
 # 2022-03-08: MTS - added partial records exception
 # 2021-03-18: CJM - Included contour plotting and HMB
+# 2021-03-31: CJM - Map info included
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
@@ -64,7 +65,8 @@ class Maps():
                      colorbar: bool = True, colorbar_label: str = '',
                      title: str = '', zmin: float = None, zmax: float = None,
                      hmb: bool = True, boundary: bool = False,
-                     radar_location: bool = False, **kwargs):
+                     radar_location: bool = False, map_info: bool = True,
+                     **kwargs):
         """
         Plots convection maps data points and vectors
 
@@ -300,6 +302,13 @@ class Maps():
                               end_minute=str(dmap_data[record]['end.minute']).
                               zfill(2))
         plt.title(title)
+
+        if map_info is True:
+            model = dmap_data[record]['model.name']
+            num_points = len(dmap_data[record]['vector.mlat'])
+            pol_cap_pot = dmap_data[record]['pot.drop']
+            cls.add_map_info(fit_order, pol_cap_pot, num_points, model)
+
         return mlats, mlons, v_mag
 
 
@@ -524,6 +533,33 @@ class Maps():
                             -velocity_fit_vectors[0, velocity_chk_zero_inds])
 
         return velocity, azm_v
+
+
+    @classmethod
+    def add_map_info(cls, fit_order: float, pol_cap_pot: float,
+                     num_points: float, model: str):
+        """
+        Annotates the plot with information about the map plotting
+
+        Parameters
+        ----------
+            ax: object
+                matplotlib axis object
+            fit_order: int
+                order of the fit
+            pol_cap_pot: float
+                value of the polar cap potential in kV
+            num_points: int
+                number of vectors plotted
+            model: str
+                model used to fit data
+        """
+        text_string = r'$\phi_{PC}$' + ' = ' + str(round(pol_cap_pot/1000))\
+                      + ' kV\n' \
+                      + 'N = ' + str(num_points) + '\n' \
+                      + 'Order: ' + str(fit_order) + '\n' \
+                      + 'Model: ' + model + '\n'
+        plt.figtext(0.1, 0.1, text_string)
 
 
     @classmethod


### PR DESCRIPTION
# Scope 

This PR adds requested map file info onto the map plot in the bottom left corner.
Currently included are: cross polar cap potential, number of vectors, fit order and model used. Let me know if any others are wanted, we can always do an extended optional version with all the lesser used values. 
**This will cause merge conflicts with the IMF dial, just make sure that the IMF dial is below this new code when sorting conflicts**

**issue:** to close #252 

## Approval

**Number of approvals:** 1

## Test

**matplotlib version**: 3.5.1
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt
import pydarn
map_file = "/Users/carley/Documents/data/maps/20150310.n.map"
map_data = pydarn.SuperDARNRead().read_dmap(map_file)
pydarn.Maps.plot_mapdata(map_data,record=180, 
            parameter=pydarn.MapParams.FITTED_VELOCITY,
            lowlat=60)
plt.show()
```
gives:
<img width="742" alt="Screen Shot 2022-03-31 at 3 19 57 PM" src="https://user-images.githubusercontent.com/60905856/161152683-3cff37bc-d853-4924-84d1-7d1f4eb506de.png">
<img width="187" alt="Screen Shot 2022-03-31 at 3 20 04 PM" src="https://user-images.githubusercontent.com/60905856/161152695-d9b2d1ef-fe41-4336-8047-ad8146e685ee.png">

*Reminder, please check your code is:
  - copyrighted (if applicable)
  - Appropriate disclaimer added
  - Modification line filled in (if applicable)*
