### PR TITLE
FIX: mlon shifting to MLT for HMB and contours

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -267,7 +267,8 @@ class Maps():
 
         cls.plot_potential_contours(fit_coefficient, lat_min, date,
                                     lat_shift=lat_shift, lon_shift=lon_shift,
-                                    fit_order=fit_order, **kwargs)
+                                    fit_order=fit_order, hemisphere=hemisphere,
+                                    **kwargs)
 
         if hmb is True:
             # Plot the HMB
@@ -670,7 +671,7 @@ class Maps():
     def calculate_potentials(cls, fit_coefficient: list, lat_min: list,
                              lat_shift: int = 0, lon_shift: int = 0,
                              fit_order: int = 6, lowlat: int = 60,
-                             hemisphere: Hemisphere = Hemisphere.North,
+                             hemisphere: Enum = Hemisphere.North,
                              **kwargs):
         # TODO: No evaluation of coordinate system made! May need if in
         # plotting to plot in radians/geo ect.
@@ -703,7 +704,7 @@ class Maps():
 
         '''
         # Lowest latitude to calculate potential to
-        theta_max = np.radians(90-np.abs(lat_min))
+        theta_max = np.radians(90-np.abs(lat_min)) * hemisphere.value
 
         # Make a grid of the space the potential is evaluated on
         # in magnetic coordinates
@@ -712,7 +713,6 @@ class Maps():
         num_lats = int((90.0 - lowlat) / lat_step) + 1
         num_lons = int(360.0 / lon_step) + 1
         lat_arr = np.array(range(num_lats)) * lat_step + lowlat
-        lat_arr = lat_arr * hemisphere.value
         lon_arr = np.array(range(num_lons)) * lon_step
 
         # Set up Grid
@@ -767,10 +767,12 @@ class Maps():
 
         mlat_center = grid_arr[0, :].reshape((num_lons, num_lats))
         # Set everything below the latmin as 0
-        ind = np.where(mlat_center < lat_min)
+        ind = np.where(abs(mlat_center) < abs(lat_min))
         pot_arr[ind] = 0
 
         mlon_center = grid_arr[1, :].reshape((num_lons, num_lats))
+        # Invert for Southern maps
+        mlat_center = mlat_center * hemisphere.value
 
         return mlat_center, mlon_center, pot_arr
 
@@ -779,6 +781,7 @@ class Maps():
     def plot_potential_contours(cls, fit_coefficient: list, lat_min: list,
                                 date: object, lat_shift: int = 0,
                                 lon_shift: int = 0, fit_order: int = 6,
+                                hemisphere: Enum = Hemisphere.North,
                                 contour_levels: list = [],
                                 contour_color: str = 'dimgrey',
                                 contour_linewidths: float = 0.8,
@@ -859,7 +862,8 @@ class Maps():
         mlat, mlon_u, pot_arr = cls.calculate_potentials(
                              fit_coefficient, lat_min,
                              lat_shift=lat_shift, lon_shift=lon_shift,
-                             fit_order=fit_order, **kwargs)
+                             fit_order=fit_order, hemisphere=hemisphere,
+                             **kwargs)
 
         # Shift mlon to MLT
         shifted_mlts = mlon_u[0, 0] - \


### PR DESCRIPTION
# Scope 

This PR fixes a bug in the contour plotting in convection maps. A TODO I left out was to add the mlon shifting to MLT out of the functions for plotting HMB and contours. It just so happened that the data we were all testing was generally from the same time of the day where the shift is minimal- but if testing in the early hours or late at night you can see the issue. 
**IF ANYONE HAS SOUTHERN HEMISPHERE MAP DATA PLEASE TEST ME!**

This will probably be required for the release branch as the release branch and develop right now are incorrect in plotting these two.

The vector plotting is all okay though!

**issue:** NA

## Approval

**Number of approvals:** 2 please - to make sure it's scientifically correct

## Test

**matplotlib version**:  3.5.1 
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt
import pydarn

map_file = "/Users/carley/Documents/data/maps/20150310.n.map"
map_data = pydarn.SuperDARNRead().read_dmap(map_file)

pydarn.Maps.plot_mapdata(map_data,record=60, 
            parameter=pydarn.MapParams.FITTED_VELOCITY,
            lowlat=60)
plt.show()
```
Will now give:
<img width="554" alt="Screen Shot 2022-04-01 at 2 46 26 PM" src="https://user-images.githubusercontent.com/60905856/161340225-7b0b1953-bb49-42c2-9f12-16c5b2369958.png">

This is what it looked like before this fix on current release and develop branch:
<img width="557" alt="Screen Shot 2022-04-01 at 2 36 41 PM" src="https://user-images.githubusercontent.com/60905856/161340267-7fefa217-6502-4326-841d-03e70e29fb20.png">


*Reminder, please check your code is:
  - copyrighted (if applicable)
  - Appropriate disclaimer added
  - Modification line filled in (if applicable)*
