### PR TITLE
comments out setting min start on beam_corners_lats and beam_corners_lons in geo_coordinates function

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -220,12 +220,13 @@ class Fan():
                                                  " out at "\
                                                  "https://github.com"\
                                                  "/SuperDARN/pyDARN")
-
+      
         beam_corners_lats, beam_corners_lons =\
                 coords(stid=dmap_data[0]['stid'],
                        rsep=rsep, frang=frang,
                        gates=ranges, date=date,
                        **kwargs)
+
 
         fan_shape = beam_corners_lons.shape
         if ranges[0] < ranges[1] - fan_shape[0]:
@@ -241,6 +242,7 @@ class Fan():
         # both ends for the ranges given
         scan = np.zeros((fan_shape[0], fan_shape[1]-1))
         grndsct = np.zeros((fan_shape[0], fan_shape[1]-1))
+
         # Colour table and max value selection depending on parameter plotted
         # Load defaults if none given
         if cmap is None:
@@ -280,14 +282,14 @@ class Fan():
                 slist = slist[good_data]
                 temp_data = dmap_data[i.astype(int)][parameter][good_data]
                 temp_ground = dmap_data[i.astype(int)]['gflg'][good_data]
-
                 scan[slist-ranges[0], beam] = temp_data
                 grndsct[slist-ranges[0], beam] = temp_ground
+                # import pdb; pdb.set_trace()
             # if there is no slist field this means partial record
             except KeyError:
                 partial_record_warning()
                 continue
-
+        import pdb; pdb.set_trace()
         # Begin plotting by iterating over ranges and beams
 
         thetas = thetas[0:ranges[1]-ranges[0]+1]

--- a/pydarn/testing.py
+++ b/pydarn/testing.py
@@ -1,0 +1,58 @@
+#%%
+import pydarn
+import pydarnio
+
+import matplotlib.pyplot as plt
+from datetime import datetime
+from pydarn import Coords
+
+
+#Read in fitACF file using SuperDARDRead, then read_fitacf
+# sps_fitacf_file = 'home/fran/code/SuperdarnW3usr/ForGitRepo/data_vt_mcm/'
+mcm_fitacf_file = '/home/fran/code/SuperdarnW3usr/20170101.0000.01.mcm.a.fitacf'
+
+# sps_fitacf_reader = pydarnio.SDarnRead(sps_fitacf_file)
+# sps_fitacf_data = sps_fitacf_reader.read_fitacf()
+
+mcm_fitacf_reader = pydarnio.SDarnRead(mcm_fitacf_file)
+mcm_fitacf_data = mcm_fitacf_reader.read_fitacf()
+
+
+"""fig = plt.figure(figsize=(12,12))
+kwargs1 = {
+    'boundary': True,
+    'groundscatter': True,
+    'scan_index':22,
+    'line_color':'red',
+    'radar_label': True,
+}
+
+pydarn.Fan.plot_fan(sps_fitacf_data,colorbar=True, **kwargs1)
+pydarn.Fan.plot_fan(mcm_fitacf_data,colorbar=False, **kwargs1)"""
+
+
+
+# pydarn.Fan.plot_fan(sps_fitacf_data,colorbar=True, **kwargsl2)
+# pydarn.Fan.plot_fan(mcm_fitacf_data,colorbar=False, **kwargsl2)
+
+fig1 = plt.figure(figsize=(12,12))
+kwargs2 = {
+    'boundary': True,
+    'zmax': 200,
+    'zmin': -200,
+    'groundscatter': False,
+    'scan_index':22,
+    'colorbar_label':'Power [dB]',
+    'cmap':'viridis',
+    'line_color':'red',
+    'radar_label': True,
+    'parameter': 'p_l',
+    'coords': Coords.SLANT_RANGE
+}
+
+# pydarn.Fan.plot_fan(sps_fitacf_data,colorbar=True, **kwargs2)
+pydarn.Fan.plot_fan(mcm_fitacf_data,colorbar=False)
+
+
+plt.show()
+# %%

--- a/pydarn/utils/coordinates.py
+++ b/pydarn/utils/coordinates.py
@@ -28,6 +28,7 @@ from pydarn import (geocentric_coordinates, SuperDARNRadars, RangeEstimation,
                     radar_exceptions, Re)
 
 
+
 def geo_coordinates(stid: int, beams: int = None,
                     gates: tuple = None, **kwargs):
     """
@@ -55,8 +56,9 @@ def geo_coordinates(stid: int, beams: int = None,
                                                 **kwargs)
             beam_corners_lats[gate-gates[0], beam] = lat
             beam_corners_lons[gate-gates[0], beam] = lon
-    y0inx = np.min(np.where(np.isfinite(beam_corners_lats[:,0]))[0])
-    return beam_corners_lats[y0inx:], beam_corners_lons[y0inx:]
+    # import ipdb;ipdb.set_trace()
+    # y0inx = np.min(np.where(np.isfinite(beam_corners_lats[:,0]))[0])
+    return beam_corners_lats, beam_corners_lons
 
 
 def aacgm_coordinates(stid: int, beams: int = None, gates: tuple = None,
@@ -214,6 +216,7 @@ class Coords(enum.Enum):
     GEOGRAPHIC = (geo_coordinates, )
     AACGM = (aacgm_coordinates, )
     AACGM_MLT = (aacgm_MLT_coordinates, )
+    SLANT_RANGE =(gate2geographic_location, )
 
     # Need this to make the functions callable
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
# Scope 

This PR comments out  # y0inx = np.min(np.where(np.isfinite(beam_corners_lats[:,0]))[0]) in the geo_coordinates function in coordinates.py. Since we need to return all of the beam_corners_lats and beam_corners_lons.

**issue:**

## Approval

**Number of approvals:** 3

## Test
import pydarn
import pydarnio

import matplotlib.pyplot as plt
from datetime import datetime
from pydarn import Coords


#Read in fitACF file using SuperDARDRead, then read_fitacf
sps_fitacf_file = 'data_vt_sps/20170124.0000.01.sps.a.fitacf'

sps_fitacf_reader = pydarnio.SDarnRead(sps_fitacf_file)
sps_fitacf_data = sps_fitacf_reader.read_fitacf()


fig = plt.figure(figsize=(12,12))
kwargs1 = {
    'boundary': True,
    'groundscatter': True,
    'scan_index':22,
    'line_color':'red',
    'radar_label': True,
}

ax, beam_corners_lats, beam_corners_lons, scan, grndsct = pydarn.Fan.plot_fan(sps_fitacf_data,colorbar=True, **kwargs1)
