### PR TITLE
comments out setting min start on beam_corners_lats and beam_corners_lons in geo_coordinates function

### DIFF
--- a/pydarn/utils/coordinates.py
+++ b/pydarn/utils/coordinates.py
@@ -55,8 +55,8 @@ def geo_coordinates(stid: int, beams: int = None,
                                                 **kwargs)
             beam_corners_lats[gate-gates[0], beam] = lat
             beam_corners_lons[gate-gates[0], beam] = lon
-    y0inx = np.min(np.where(np.isfinite(beam_corners_lats[:,0]))[0])
-    return beam_corners_lats[y0inx:], beam_corners_lons[y0inx:]
+    # y0inx = np.min(np.where(np.isfinite(beam_corners_lats[:,0]))[0])
+    return beam_corners_lats, beam_corners_lons
 
 
 def aacgm_coordinates(stid: int, beams: int = None, gates: tuple = None,


### PR DESCRIPTION
# Scope 
This PR comments out # y0inx = np.min(np.where(np.isfinite(beam_corners_lats[:,0]))[0]) in the geo_coordinates function in coordinates.py. Since we need to return all of the beam_corners_lats and beam_corners_lons.

## Approval

**Number of approvals:** 3

## Test
```
import pydarn
import pydarnio

import matplotlib.pyplot as plt
from datetime import datetime
from pydarn import Coords

#Read in fitACF file using SuperDARDRead, then read_fitacf
sps_fitacf_file = 'data_vt_sps/20170124.0000.01.sps.a.fitacf'

sps_fitacf_reader = pydarnio.SDarnRead(sps_fitacf_file)
sps_fitacf_data = sps_fitacf_reader.read_fitacf()

fig = plt.figure(figsize=(12,12))
kwargs1 = {
'boundary': True,
'zmax': 200,
'zmin': -200,
'groundscatter': False,
'scan_index':22,
'colorbar_label':'Power [dB]',
'line_color':'red',
'radar_label': True,
'parameter': 'p_l',
'coords': Coords.GEOGRAPHIC
}

ax, beam_corners_lats, beam_corners_lons, scan, grndsct = \
    pydarn.Fan.plot_fan(sps_fitacf_data, colorbar=True, **kwargs1)
    
plt.show()
```