### PR TITLE
New Feature: HALF_SLANT option for RangeEstimate

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -1115,7 +1115,8 @@ class RTP():
                 # on the velocity plot. This may change in the future.
                 if range_estimation == RangeEstimation.SLANT_RANGE:
                     ymax = 3517.5
-                elif range_estimation == RangeEstimation.GSMR:
+                elif range_estimation == RangeEstimation.GSMR or \
+                        range_estimation == RangeEstimation.HALF_SLANT:
                     ymax = 3517.5/2
                 else:
                     ymax = 75
@@ -1164,6 +1165,8 @@ class RTP():
                     axes[i].set_ylabel('Slant Range (km)')
                 elif range_estimation == RangeEstimation.GSMR:
                     axes[i].set_ylabel('Ground Scatter\nMapped Range\n(km)')
+                elif range_estimation == RangeEstimation.HALF_SLANT:
+                    axes[i].set_ylabel('Slant Range/2\n(km)')
                 else:
                     axes[i].set_ylabel('Range Gates')
             if i < num_plots-1:

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -8,6 +8,7 @@
 # 2021-06-18 Marina Schmidt (SuperDARN Canada) fixed ground scatter colour bug
 # 2021-07-06 Carley Martin added keyword to aid in rounding start times
 # 2022-03-04 Marina Schmidt added RangeEstimations in
+# 2022-08-04 Carley Martin added elifs for HALF_SLANT options
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md

--- a/pydarn/utils/range_estimations.py
+++ b/pydarn/utils/range_estimations.py
@@ -15,9 +15,26 @@
 
 import enum
 import numpy as np
-import math
 
 from pydarn import Re, C
+
+
+def gate2halfslant(**kwargs):
+    """
+    Calculate the slant range divided by 2 for each range gate
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        half_slant : np.array
+            returns an array of slant ranges divided by two for the radar
+    """
+    slant_range = gate2slant(**kwargs)
+    half_slant = slant_range / 2
+    return half_slant
 
 
 def gate2groundscatter(reflection_height: float = 250, **kwargs):
@@ -119,6 +136,7 @@ class RangeEstimation(enum.Enum):
 
     RANGE_GATE = enum.auto()
     SLANT_RANGE = (gate2slant,)
+    HALF_SLANT = (gate2halfslant,)
     GSMR = (gate2groundscatter,)
 
     # Need this to make the functions callable

--- a/pydarn/utils/range_estimations.py
+++ b/pydarn/utils/range_estimations.py
@@ -11,6 +11,7 @@
 # supplemented by the additional permissions listed below.
 #
 # Modifications:
+# 2022-08-04 CJM added HALF_SLANT option and gate2halfslant method
 #
 
 import enum


### PR DESCRIPTION
# Scope 

This PR adds an option to plot *HALF_SLANT* in fan plots and range time plots. Half slant is equal to *SLANT_RANGE* options divided by 2. This is considered better(?) than using GSMR option. 
 https://doi.org/10.1029/2022RS007429

**issue:** #273 

## Approval

**Number of approvals:** 2 please, lots of plotting testing

## Test

**matplotlib version**: 3.5.2
**Note testers: please indicate what version of matplotlib you are using**

Summary plots:
```python
import matplotlib.pyplot as plt 
import pydarn

file = "/Users/carley/Documents/data/20131031.2201.00.sas.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

a = pydarn.RTP.plot_summary(fitacf_data, beam_num=2, range_estimation=pydarn.RangeEstimation.HALF_SLANT)
plt.show()
```
Gives: 
![Screen Shot 2022-08-04 at 9 38 57 AM](https://user-images.githubusercontent.com/60905856/182890949-419c3533-ddc4-4107-99b3-68383bd80ed5.png)

Fan plots (comparison with SLANT_RANGE):
```python
import matplotlib.pyplot as plt
import pydarn

file='/Users/carley/Documents/data/20150308.1400.03.cly.fitacf'
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

# Half Slant
pydarn.Fan.plot_fan(fitacf_data, scan_index=5,
                    radar_label=True, lowlat=50,
                    range_estimation=pydarn.RangeEstimation.HALF_SLANT)
plt.show()

# Slant range
pydarn.Fan.plot_fan(fitacf_data, scan_index=5,
                    radar_label=True, lowlat=50)
plt.show()
```
Gives:

<img width="643" alt="Screen Shot 2022-08-04 at 9 22 08 AM" src="https://user-images.githubusercontent.com/60905856/182891390-3faaa09b-32ba-44ee-a7fa-526898dcdd30.png">
<img width="711" alt="Screen Shot 2022-08-04 at 9 22 23 AM" src="https://user-images.githubusercontent.com/60905856/182891391-a3d130d9-f05a-4dcb-bb17-65779e7cabfd.png">

