### PR TITLE
EHN: Speed up common use of convection maps

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -9,6 +9,7 @@
 # 2022-04-01: CJM - Bug fix for lon shifting to MLT
 # 2022-04-28: CJM - Added option to have single color vectors with reference
 #                   vector
+# 2022-08-15: CJM - Removed plot_FOV call for default uses
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -203,7 +203,7 @@ class Maps():
                                          radar_location=radar_location,
                                          **kwargs)
             else:
-                ax, _ = projs(date, ax=ax, **kwargs)
+                ax, _ = projs(date, ax=ax, hemisphere=hemisphere, **kwargs)
 
         if parameter == MapParams.MODEL_VELOCITY:
             try:


### PR DESCRIPTION
# Scope 

This PR speeds up the plotting of default convection maps when the user doesn't want FOV or radar locations (which is default).
If boundary (FOV) = False and radar_location=False then the code will now skip calling the plot_FOV function and call a basic projection to get the axes. If either are True, then it will call each FOV to plot individually as before. 

This removes ~13 seconds from the plotting time of one convection map, reducing the total time taken by 2/3, yay!
Using the coastline=True option will increase time taken, as its calling some Cartopy functions and then is converted to MLT, by 2 seconds. If coastlines=False, then the whole axis plotting is now only 0.1 seconds, making a vast improvement on speed. 

The remaining time taken (~6 seconds) is plotting the contours, specifically calling the special.lpmn function ~7000 times to calculate the Legendre functions - this function can only take scalar values so cannot be vectorized to speed it up unfortunately so I don't see an easy way to save time here.

Also added a warning as we are not actively developing maps with other projections.

**issue:** #276 

## Approval

**Number of approvals:** It's a simple if loop so probably 1 good test and review is okay. 

## Test

**matplotlib version**: 3.5.3
**Note testers: please indicate what version of matplotlib you are using**
```python
import pydarn
import datetime as dt

map_file = "/Users/carley/Documents/data/maps/20150310.n.map"
map_data = pydarn.SuperDARNRead().read_dmap(map_file)

# Requires Cartopy installation for coastlines - just remove coastlines for non-cartopy
pydarn.Maps.plot_mapdata(map_data,record=360, 
            parameter=pydarn.MapParams.FITTED_VELOCITY,
            lowlat=50, color_vectors=False,
            contour_fill=True, coastline=True)
plt.show()
```
Produces:
<img width="742" alt="Screen Shot 2022-08-16 at 1 03 07 PM" src="https://user-images.githubusercontent.com/60905856/184961223-d7d0095b-1a5f-41b4-848c-1fd8ae6a870b.png">


**Note: double check that hemisphere is being read into projs for southern data to work too**

**Note: check grid plots for same issue**