### PR TITLE
FIX: Geographic projection extents now tied to user inputted or default 'lowlat' value

### DIFF
--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -183,6 +183,7 @@ def axis_geological(date, ax: object = None,
         pole_lat = -90
         noon = 360 - deg_from_midnight
         ylocations = 5
+        lowlat = -abs(lowlat)
     # handle none types or wrongly built axes
     proj = ccrs.Orthographic(noon, pole_lat)
 
@@ -191,12 +192,8 @@ def axis_geological(date, ax: object = None,
         if grid_lines:
             ax.gridlines(draw_labels=True)
 
-        extent = min(45e5,
-                     (abs(proj.transform_point(noon, lowlat,
-                                               ccrs.PlateCarree())
-                          [1])))
-        ax.set_extent(extents=(-extent, extent, -extent, extent),
-                      crs=proj)
+        extent = abs(proj.transform_point(noon, lowlat, ccrs.PlateCarree())[1])
+        ax.set_extent(extents=(-extent, extent, -extent, extent), crs=proj)
 
     if coastline is True:
         ax.coastlines()


### PR DESCRIPTION
# Scope 

This PR fixes the 'extents' of the geographic fan/grid plots so that the inputted lowlat value is used.
Also included is a fix for lowlat values for southern data. 

There is a known error in the Geographic grid plots when plotting multiple fans, please ignore for now that fix is out of scope for this PR, this fix is purely for the low latitude boundary.

**PLEASE ALSO NOTE THAT THE DIFFERENT PROJECTIONS DISPLAY DIFFERENTLY FOR SOUTHERN DATA**
Geographic projections will appear as if looking up at the South pole, polar projections will appear as if looking *through* the Earth from above to the South pole as is common for hemisphere comparisons - I have added this to the documentation issue to make sure it is stated somewhere. 

Map plots only use polar projection so this will not affect them at all.

**issue:** #271 

## Approval

**Number of approvals:** 2 please as it effects fan, fov and grid plots *PLEASE TEST ON SOUTHERN DATA TOO!*

## Test

**matplotlib version**: 3.5.3
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt
import pydarn

#file='/Users/carley/Documents/data/20150308.1400.03.cly.fitacf'
file='/Users/carley/Documents/data/20161123.1601.00.mcm.a.fitacf'
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

# Geographic Geo
pydarn.Fan.plot_fan(fitacf_data, scan_index=5,
                    groundscatter=True, lowlat=10,
                    coords=pydarn.Coords.GEOGRAPHIC, projs=pydarn.Projs.GEO,
                    coastline=True)
plt.show()

# Magnetic Polar
pydarn.Fan.plot_fan(fitacf_data, scan_index=5,
                    groundscatter=True, lowlat=50,
                    coastline=True)
plt.show()

grid_file = "/Users/carley/Documents/data/grids/20011220.8000.grid"
grid_data = pydarn.SuperDARNRead(grid_file).read_grid()

# Geographic Geo
# THERE IS A KNOWN OTHER ISSUE IN THIS METHOD OUT OF SCOPE FOR THIS PR
gridplot = pydarn.Grid.plot_grid(grid_data, parameter = 'vel', fov_color='grey', 
                lowlat=30, coastline=True, coords=pydarn.Coords.GEOGRAPHIC,
                projs=pydarn.Projs.GEO)
plt.show()

# Magnetic Polar
gridplot = pydarn.Grid.plot_grid(grid_data, parameter = 'vel', fov_color='grey', 
                lowlat=30, coastline=True)
plt.show()
```
This produces the following plots in order:
Fan plot in geographic coordinates and geographic projection:
<img width="613" alt="Screen Shot 2022-08-16 at 3 07 42 PM" src="https://user-images.githubusercontent.com/60905856/184985502-aa04f031-7d39-4983-b5ca-af7be23140fa.png">

Fan plot in AACGM coordinates and polar projection:
<img width="644" alt="Screen Shot 2022-08-16 at 3 07 57 PM" src="https://user-images.githubusercontent.com/60905856/184985520-61ec76bf-41f5-4139-91b1-e4ccc0c7a5c3.png">

GRID plot in geographic coordinates and geographic projection (with known error):
<img width="572" alt="Screen Shot 2022-08-16 at 3 08 06 PM" src="https://user-images.githubusercontent.com/60905856/184985539-f0395271-e77d-4336-9c6b-02712a944d84.png">

GRID plot in AACGM coordinates and polar projection:
<img width="642" alt="Screen Shot 2022-08-16 at 3 08 22 PM" src="https://user-images.githubusercontent.com/60905856/184985560-045f3d6a-52bf-4fee-ae5a-952dbb765011.png">

