### PR TITLE
EHN: Geo/AACGM Lat/Lon and MLT as y-axis options for RTP

### DIFF
--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -44,7 +44,7 @@ from .utils.constants import C
 from .utils.virtual_heights import VHModels
 from .utils.geo import geocentric_coordinates
 from .utils.superdarn_radars import SuperDARNRadars
-from .utils.range_estimations import RangeEstimation
+from .utils.range_estimations import RangeEstimation, km2geo, km2mag
 from .utils.conversions import dmap2dict
 from .utils.plotting import MapParams
 from .utils.plotting import check_data_type

--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -41,20 +41,20 @@ from .exceptions.warning_formatting import cartopy_print_warning
 from .utils.constants import Re
 from .utils.constants import EARTH_EQUATORIAL_RADIUS
 from .utils.constants import C
-from .utils.range_estimations import RangeEstimation
 from .utils.virtual_heights import VHModels
+from .utils.geo import geocentric_coordinates
+from .utils.superdarn_radars import SuperDARNRadars
+from .utils.range_estimations import RangeEstimation
 from .utils.conversions import dmap2dict
 from .utils.plotting import MapParams
 from .utils.plotting import check_data_type
 from .utils.plotting import time2datetime
 from .utils.plotting import find_record
-from .utils.superdarn_radars import SuperDARNRadars
 from .utils.superdarn_cpid import SuperDARNCpids
 from .utils.superdarn_radars import Hemisphere
 from .utils.superdarn_radars import read_hdw_file
 from .utils.superdarn_radars import get_hdw_files
 from .utils.scan import build_scan
-from .utils.geo import geocentric_coordinates
 from .utils.coordinates import Coords
 
 # import plotting

--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -44,7 +44,7 @@ from .utils.constants import C
 from .utils.virtual_heights import VHModels
 from .utils.geo import geocentric_coordinates
 from .utils.superdarn_radars import SuperDARNRadars
-from .utils.range_estimations import RangeEstimation, km2geo, km2mag
+from .utils.range_estimations import RangeEstimation, km2geo, km2mag, km2mlt
 from .utils.conversions import dmap2dict
 from .utils.plotting import MapParams
 from .utils.plotting import check_data_type

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -364,9 +364,11 @@ class RTP():
                                     .hardware_info.rx_rise_time
             frang = int(cls.dmap_data[0]['frang'])
             rsep = int(cls.dmap_data[0]['rsep'])
+            stid = cls.dmap_data[0]['stid']
 
             y = range_estimation(frang=frang, rxrise=rxrise,
-                                 rsep=rsep, nrang=y_max, **kwargs)
+                                 rsep=rsep, nrang=y_max, beam=beam_num,
+                                 stid=stid, date=start_time, **kwargs)
 
             y0inx = np.min(np.where(np.isfinite(y))[0])
             y = y[y0inx:]

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -475,15 +475,6 @@ class RTP():
                                        beam=beam_num, date=start_time)
             coordinate = [str(round(x, 1)) for x in coordinate]
             ax.set_yticklabels(coordinate)
-        elif coords == Coords.AACGM_MLT:
-            # For magnetic axes, plot in km then change the labels
-            tick_vals = np.arange(np.ceil(ymin/100.0)*100,
-                                  ymax+1, yspacing)
-            ax.yaxis.set_ticks(tick_vals)
-            coordinate = km2mlt(tick_vals, stid=cls.dmap_data[0]['stid'],
-                                beam=beam_num, date=start_time,)
-            coordinate = [str(round(x, 1)) for x in coordinate]
-            ax.set_yticklabels(coordinate)
 
         # SuperDARN file typically are in 2hr or 24 hr files
         # to make the minute ticks sensible, the time length is detected
@@ -1230,8 +1221,6 @@ class RTP():
                     axes[i].set_ylabel('Geographic\nLongitude (°)')
                 elif coords == Coords.AACGM and lat_or_lon == 'lon':
                     axes[i].set_ylabel('AACGM\nLongitude (°)')
-                elif coords == Coords.AACGM_MLT:
-                    axes[i].set_ylabel('Magnetic\nLocal Time')
             if i < num_plots-1:
                 axes[i].set_xticklabels([])
             # last plot needs the label on the x-axis

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -9,6 +9,7 @@
 # 2021-07-06 Carley Martin added keyword to aid in rounding start times
 # 2022-03-04 Marina Schmidt added RangeEstimations in
 # 2022-08-04 Carley Martin added elifs for HALF_SLANT options
+# 2022-08-18 Carley Martin added options to plot y-axis in geo and mag coords
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -1220,6 +1220,8 @@ class RTP():
                 elif range_estimation == RangeEstimation.HALF_SLANT and \
                         coords is None:
                     axes[i].set_ylabel('Slant Range/2\n(km)')
+                elif range_estimation == RangeEstimation.RANGE_GATE:
+                    axes[i].set_ylabel('Range Gates')
                 elif coords == Coords.GEOGRAPHIC and lat_or_lon == 'lat':
                     axes[i].set_ylabel('Geographic\nLatitude (°)')
                 elif coords == Coords.AACGM and lat_or_lon == 'lat':
@@ -1230,8 +1232,6 @@ class RTP():
                     axes[i].set_ylabel('AACGM\nLongitude (°)')
                 elif coords == Coords.AACGM_MLT:
                     axes[i].set_ylabel('Magnetic\nLocal Time')
-                else:
-                    axes[i].set_ylabel('Range Gates')
             if i < num_plots-1:
                 axes[i].set_xticklabels([])
             # last plot needs the label on the x-axis

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -78,7 +78,7 @@ class RTP():
                         range_estimation: RangeEstimation =
                         RangeEstimation.SLANT_RANGE,
                         coords: object = None, lat_or_lon: str = 'lat',
-                        secondary_yaxis: dict={} ,colorbar_label: str = '',
+                        colorbar_label: str = '',
                         norm=colors.Normalize, cmap: str = None,
                         filter_settings: dict = {},
                         date_fmt: str = '%y/%m/%d\n %H:%M',
@@ -138,14 +138,6 @@ class RTP():
             choose the latitude or longitude of a coordinate range estimation
             if chosen
             Default: lat
-        secondary_yaxis: dict
-            pass information to the plotting to make a secondary y axis for the
-            range-time plots,
-            example:
-            secondary_axis=
-                    {'range_estimation': pyDARN.RangeEstimation.AACGM_GSMR,
-                     'lat_or_lon': 'lon'}
-            Default: dict = {} (no secondary axis)
         norm: matplotlib.colors.Normalization object
             This object use dependency injection to use any normalization
             method with the zmin and zmax.
@@ -449,43 +441,47 @@ class RTP():
 
         if range_estimation == RangeEstimation.RANGE_GATE:
             ax.yaxis.set_ticks(np.arange(ymin, ymax+1, (ymax)/5))
-        elif coords == None:
+        elif coords is None:
             ax.yaxis.set_ticks(np.arange(np.ceil(ymin/100.0)*100,
                                          ymax+1, yspacing))
         elif coords == Coords.GEOGRAPHIC:
             # For geographic axes, plot in km then change the labels
             tick_vals = np.arange(np.ceil(ymin/100.0)*100,
-                                         ymax+1, yspacing)
+                                  ymax+1, yspacing)
             ax.yaxis.set_ticks(tick_vals)
             if lat_or_lon == 'lat':
-                coordinate, _ = km2geo(tick_vals, stid=cls.dmap_data[0]['stid'],
+                coordinate, _ = km2geo(tick_vals,
+                                       stid=cls.dmap_data[0]['stid'],
                                        beam=beam_num)
             else:
-                _, coordinate = km2geo(tick_vals, stid=cls.dmap_data[0]['stid'],
+                _, coordinate = km2geo(tick_vals,
+                                       stid=cls.dmap_data[0]['stid'],
                                        beam=beam_num)
-            coordinate = [str(round(x,1)) for x in coordinate]
+            coordinate = [str(round(x, 1)) for x in coordinate]
             ax.set_yticklabels(coordinate)
         elif coords == Coords.AACGM:
             # For magnetic axes, plot in km then change the labels
             tick_vals = np.arange(np.ceil(ymin/100.0)*100,
-                                         ymax+1, yspacing)
+                                  ymax+1, yspacing)
             ax.yaxis.set_ticks(tick_vals)
             if lat_or_lon == 'lat':
-                coordinate, _ = km2mag(tick_vals, stid=cls.dmap_data[0]['stid'],
+                coordinate, _ = km2mag(tick_vals,
+                                       stid=cls.dmap_data[0]['stid'],
                                        beam=beam_num, date=start_time)
             else:
-                _, coordinate = km2mag(tick_vals, stid=cls.dmap_data[0]['stid'],
+                _, coordinate = km2mag(tick_vals,
+                                       stid=cls.dmap_data[0]['stid'],
                                        beam=beam_num, date=start_time)
-            coordinate = [str(round(x,1)) for x in coordinate]
+            coordinate = [str(round(x, 1)) for x in coordinate]
             ax.set_yticklabels(coordinate)
         elif coords == Coords.AACGM_MLT:
             # For magnetic axes, plot in km then change the labels
             tick_vals = np.arange(np.ceil(ymin/100.0)*100,
-                                         ymax+1, yspacing)
+                                  ymax+1, yspacing)
             ax.yaxis.set_ticks(tick_vals)
             coordinate = km2mlt(tick_vals, stid=cls.dmap_data[0]['stid'],
                                 beam=beam_num, date=start_time,)
-            coordinate = [str(round(x,1)) for x in coordinate]
+            coordinate = [str(round(x, 1)) for x in coordinate]
             ax.set_yticklabels(coordinate)
 
         # SuperDARN file typically are in 2hr or 24 hr files
@@ -1167,7 +1163,7 @@ class RTP():
                 if range_estimation == RangeEstimation.SLANT_RANGE:
                     ymax = 3517.5
                 elif range_estimation == RangeEstimation.GSMR or \
-                      range_estimation == RangeEstimation.HALF_SLANT:
+                        range_estimation == RangeEstimation.HALF_SLANT:
                     ymax = 3517.5/2
                 else:
                     ymax = 75
@@ -1195,7 +1191,7 @@ class RTP():
                                             background=background,
                                             range_estimation=range_estimation,
                                             coords=coords,
-                                            lat_or_lon = lat_or_lon,
+                                            lat_or_lon=lat_or_lon,
                                             **kwargs)
                 # Overwriting velocity ticks to get a better pleasing
                 # look on the colorbar
@@ -1215,13 +1211,13 @@ class RTP():
                         ticks[-1] = boundary_ranges[axes_parameters[i]][1]
                     cbar.set_ticks(ticks)
                 if range_estimation == RangeEstimation.SLANT_RANGE and \
-                        coords == None:
+                        coords is None:
                     axes[i].set_ylabel('Slant Range (km)')
                 elif range_estimation == RangeEstimation.GSMR and \
-                        coords == None:
+                        coords is None:
                     axes[i].set_ylabel('Ground Scatter\nMapped Range\n(km)')
                 elif range_estimation == RangeEstimation.HALF_SLANT and \
-                        coords == None:
+                        coords is None:
                     axes[i].set_ylabel('Slant Range/2\n(km)')
                 elif coords == Coords.GEOGRAPHIC and lat_or_lon == 'lat':
                     axes[i].set_ylabel('Geographic\nLatitude (°)')
@@ -1229,7 +1225,7 @@ class RTP():
                     axes[i].set_ylabel('AACGM\nLatitude (°)')
                 elif coords == Coords.GEOGRAPHIC and lat_or_lon == 'lon':
                     axes[i].set_ylabel('Geographic\nLongitude (°)')
-                elif coords == Coords.AACGM and  lat_or_lon == 'lon':
+                elif coords == Coords.AACGM and lat_or_lon == 'lon':
                     axes[i].set_ylabel('AACGM\nLongitude (°)')
                 elif coords == Coords.AACGM_MLT:
                     axes[i].set_ylabel('Magnetic\nLocal Time')

--- a/pydarn/utils/range_estimations.py
+++ b/pydarn/utils/range_estimations.py
@@ -146,42 +146,6 @@ def gate2magslant(**kwargs):
     return gate2slant(**kwargs)
 
 
-def gate2geogsmr(**kwargs):
-    """
-    Plotting in geo and mag is done in the given km ranges, then
-    the labels are converted to lat or lon in rtp.py.
-    Different methods required or RangeEstimation defaults to slant range
-    """
-    return gate2groundscatter(**kwargs)
-
-
-def gate2maggsmr(**kwargs):
-    """
-    Plotting in geo and mag is done in the given km ranges, then
-    the labels are converted to lat or lon in rtp.py.
-    Different methods required or RangeEstimation defaults to slant range
-    """
-    return gate2groundscatter(**kwargs)
-
-
-def gate2geohalf(**kwargs):
-    """
-    Plotting in geo and mag is done in the given km ranges, then
-    the labels are converted to lat or lon in rtp.py.
-    Different methods required or RangeEstimation defaults to slant range
-    """
-    return gate2halfslant(**kwargs)
-
-
-def gate2maghalf(**kwargs):
-    """
-    Plotting in geo and mag is done in the given km ranges, then
-    the labels are converted to lat or lon in rtp.py.
-    Different methods required or RangeEstimation defaults to slant range
-    """
-    return gate2halfslant(**kwargs)
-
-
 def km2geo(ranges, stid: str, beam: int, **kwargs):
     """
     Convert a value in km from the radar into a geographic
@@ -251,6 +215,25 @@ def km2mag(ranges, date: dt.datetime, **kwargs):
     return magpsn[0], magpsn[1]
 
 
+def km2mlt(ranges, date: dt.datetime, stid:str, beam: int, *kwargs):
+    """
+    Convert a value in km from the radar into a magnetic local time
+    
+    Parameters
+    ----------
+        ranges: list
+            list of distances from the radar (km)
+
+    Returns
+    -------
+        mlts: list of floats
+            magnetic local time
+    """
+    _, mlons = km2mag(ranges, date=date, stid=stid, beam=beam)
+    mlts = aacgmv2.convert_mlt(mlons, date)
+    return mlts
+
+
 class RangeEstimation(enum.Enum):
     """
     Range_Estimation class is to list the current range gate estimations
@@ -266,13 +249,6 @@ class RangeEstimation(enum.Enum):
     SLANT_RANGE = (gate2slant,)
     HALF_SLANT = (gate2halfslant,)
     GSMR = (gate2groundscatter,)
-
-    GEOGRAPHIC_SLANT = (gate2geoslant,)
-    AACGM_SLANT = (gate2magslant,)
-    GEOGRAPHIC_GSMR = (gate2geogsmr,)
-    AACGM_GSMR = (gate2maggsmr,)
-    GEOGRAPHIC_HALF = (gate2geohalf,)
-    AACGM_HALF = (gate2maghalf,)
 
     # Need this to make the functions callable
     def __call__(self, *args, **kwargs):

--- a/pydarn/utils/range_estimations.py
+++ b/pydarn/utils/range_estimations.py
@@ -12,6 +12,7 @@
 #
 # Modifications:
 # 2022-08-04 CJM added HALF_SLANT option and gate2halfslant method
+# 2022-08-18 CJM added functions to convert range to geo, mag or mlt
 #
 
 import aacgmv2

--- a/pydarn/utils/range_estimations.py
+++ b/pydarn/utils/range_estimations.py
@@ -17,7 +17,6 @@
 import aacgmv2
 import enum
 import numpy as np
-import math
 import datetime as dt
 
 
@@ -128,29 +127,11 @@ def gate2slant(rxrise: int = 0, range_gate: int = 0, frang: int = 180,
     return slant_ranges
 
 
-def gate2geoslant(**kwargs):
-    """
-    Plotting in geo and mag is done in the given km ranges, then
-    the labels are converted to lat or lon in rtp.py.
-    Different methods required or RangeEstimation defaults to slant range
-    """
-    return gate2slant(**kwargs)
-
-
-def gate2magslant(**kwargs):
-    """
-    Plotting in geo and mag is done in the given km ranges, then
-    the labels are converted to lat or lon in rtp.py.
-    Different methods required or RangeEstimation defaults to slant range
-    """
-    return gate2slant(**kwargs)
-
-
 def km2geo(ranges, stid: str, beam: int, **kwargs):
     """
     Convert a value in km from the radar into a geographic
     latitude and longitude
-    
+
     Parameters
     ----------
         ranges: list
@@ -191,9 +172,9 @@ def km2geo(ranges, stid: str, beam: int, **kwargs):
 
 def km2mag(ranges, date: dt.datetime, **kwargs):
     """
-    Convert a value in km from the radar into a magnetic 
+    Convert a value in km from the radar into a magnetic
     latitude and longitude
-    
+
     Parameters
     ----------
         ranges: list
@@ -215,10 +196,10 @@ def km2mag(ranges, date: dt.datetime, **kwargs):
     return magpsn[0], magpsn[1]
 
 
-def km2mlt(ranges, date: dt.datetime, stid:str, beam: int, *kwargs):
+def km2mlt(ranges, date: dt.datetime, stid: str, beam: int, *kwargs):
     """
     Convert a value in km from the radar into a magnetic local time
-    
+
     Parameters
     ----------
         ranges: list


### PR DESCRIPTION
# Scope 

This PR adds the option to plot the y-axis in range time plots and summary plots as geographic latitude or longitude, AACGM latitude or longitude or AACGM derived MLT.

I'm reusing the coords enum, but I'm not using the coords methods to convert. The user will choose a range estimate value from slant range, half slant range, GSMR or range gates. If the first three are chosen, the user can opt to convert the axes values into geographic latitude or longitude, magnetic latitude or longitude or MLT using the coords keyword. Latitude and longitude for both is controlled by a new keyword called 'lat_or_lon', where the user can choose 'lat' or 'lon' to input. This defaults to 'lat' with no user input. These options work for both summary and range time plots. 

Please note that this method does not 'plot' in latitude, longitude or MLT, it converts the y-axis values into a coordinate or MLT. The coordinates are not linear and sometimes reverse, as such actually plotting in those does not make sense as the plot will be a mess. The plot will plot in the range_estimate chosen, of which the values on the axis are converted. All lats lons and MLTs are rounded to nearest 1 dp.

I attempted to add a secondary axis, but it's far more work that I can do right now to get it working with summary plots and make it a nice user experience - so it's probably best as a future PR on it's own for testing purposes. 

**issue:** #272 

## Approval

**Number of approvals:** 2 please, there is ALOT of testing required for this with various different options. 

## Test

**matplotlib version**: 3.5.3
**Note testers: please indicate what version of matplotlib you are using**

This is only some of the options:
```python
import matplotlib.pyplot as plt 
import pydarn

file = "/Users/carley/Documents/data/20160120.1602.00.cly.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

# --------------Basic RANGE_GATES to compare --------------
a = pydarn.RTP.plot_range_time(fitacf_data, beam_num=10,
                               zmin=-400, zmax=400, groundscatter=True,
                               range_estimation=pydarn.RangeEstimation.RANGE_GATE)
plt.show()
a = pydarn.RTP.plot_summary(fitacf_data, beam_num=10,
                            range_estimation=pydarn.RangeEstimation.RANGE_GATE)
plt.show()

# --------------AACGM Longitude from Slant Ranges --------------
a = pydarn.RTP.plot_range_time(fitacf_data, beam_num=10,
                               zmin=-400, zmax=400, groundscatter=True,
                               range_estimation=pydarn.RangeEstimation.SLANT_RANGE,
                               coords=pydarn.Coords.AACGM,
                               lat_or_lon = 'lon')
plt.show()
a = pydarn.RTP.plot_summary(fitacf_data, beam_num=10,
                            range_estimation=pydarn.RangeEstimation.SLANT_RANGE,
                            coords=pydarn.Coords.AACGM, lat_or_lon="lon")
plt.show()

# --------------Geographic Latitude from GSMR ranges --------------
a = pydarn.RTP.plot_range_time(fitacf_data, beam_num=10,
                               zmin=-400, zmax=400, groundscatter=True,
                               range_estimation=pydarn.RangeEstimation.GSMR,
                               coords=pydarn.Coords.GEOGRAPHIC, lat_or_lon='lat')
plt.show()
a = pydarn.RTP.plot_summary(fitacf_data, beam_num=10,
                            range_estimation=pydarn.RangeEstimation.GSMR,
                            coords=pydarn.Coords.GEOGRAPHIC, lat_or_lon='lat')
plt.show()


# All options include:
# range_estimate = pydarn.RangeEstimation.RANGE_GATE
#                  pydarn.RangeEstimation.SLANT_RANGE
#                  pydarn.RangeEstimation.GSMR
#                  pydarn.RangeEstimation.HALF_SLANT

# If above chosen with no coords, coords = None and the above will be plotted.
# If coords is chosen then the above will be used to plot and then converted to
# lat or lon given below options.

# coords = pydarn.Coords.GEOGRAPHIC
#          pydarn.Coords.AACGM
#          pydarn.Coords.AACGM_MLT

# If GEOGRAPHIC or AACGM Chosen (defaults to lat)
# lat_or_lon = 'lat'
#              'lon'

# If AACGM_MLT chosen the code will plot MLT
```

And produces the following summary plots (not shown are the range-time plots produced too):
![Screen Shot 2022-08-18 at 3 24 49 PM](https://user-images.githubusercontent.com/60905856/185500152-2168f658-c127-4c4a-954c-f47cc200f3d2.png)
![Screen Shot 2022-08-18 at 3 25 18 PM](https://user-images.githubusercontent.com/60905856/185500194-c6f4ebe6-21e2-4f8c-b0ef-659b86c0c0e5.png)
![Screen Shot 2022-08-18 at 3 26 58 PM](https://user-images.githubusercontent.com/60905856/185500204-79dfb722-2b96-45a0-9374-61cfbd1de4e6.png)
It's normal for the bottom bits to fall off with GSMR- that's how it works. 
