### PR TITLE
BUG: Fix for when colour bars should not be extended below zero

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -346,8 +346,12 @@ class Fan():
                                          integer=True, nbins='auto')
             ticks = locator.tick_values(vmin=zmin, vmax=zmax)
 
-            cb = ax.figure.colorbar(mappable, ax=ax,
-                                    extend='both', ticks=ticks)
+            if zmin == 0:
+                cb = ax.figure.colorbar(mappable, ax=ax, extend='max',
+                                        ticks=ticks)
+            else:
+                cb = ax.figure.colorbar(mappable, ax=ax, extend='both',
+                                        ticks=ticks)
 
             if colorbar_label != '':
                 cb.set_label(colorbar_label)

--- a/pydarn/plotting/grid.py
+++ b/pydarn/plotting/grid.py
@@ -267,8 +267,12 @@ class Grid():
                                          integer=True, nbins='auto')
             ticks = locator.tick_values(vmin=zmin, vmax=zmax)
 
-            cb = ax.figure.colorbar(mappable, ax=ax,
-                                    extend='both', ticks=ticks)
+            if zmin == 0:
+                cb = ax.figure.colorbar(mappable, ax=ax, extend='max',
+                                        ticks=ticks)
+            else:
+                cb = ax.figure.colorbar(mappable, ax=ax, extend='both',
+                                        ticks=ticks)
 
             if colorbar_label != '':
                 cb.set_label(colorbar_label)

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -326,8 +326,13 @@ class Maps():
             locator = ticker.MaxNLocator(symmetric=True, min_n_ticks=3,
                                          integer=True, nbins='auto')
             ticks = locator.tick_values(vmin=zmin, vmax=zmax)
-            cb = ax.figure.colorbar(mappable, ax=ax,
-                                    extend='both', ticks=ticks)
+
+            if zmin == 0:
+                cb = ax.figure.colorbar(mappable, ax=ax, extend='max',
+                                        ticks=ticks)
+            else:
+                cb = ax.figure.colorbar(mappable, ax=ax, extend='both',
+                                        ticks=ticks)
 
             if colorbar_label != '':
                 cb.set_label(colorbar_label)

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -493,15 +493,22 @@ class RTP():
                 warnings.filterwarnings('error')
                 try:
                     if isinstance(norm, colors.LogNorm):
-                        cb = ax.figure.colorbar(im, ax=ax, extend='both')
+                        if zmin == 0:
+                            cb = ax.figure.colorbar(im, ax=ax, extend='max')
+                        else:
+                            cb = ax.figure.colorbar(im, ax=ax, extend='both')
                     else:
                         locator = ticker.MaxNLocator(symmetric=True,
                                                      min_n_ticks=3,
                                                      integer=True,
                                                      nbins='auto')
                         ticks = locator.tick_values(vmin=zmin, vmax=zmax)
-                        cb = ax.figure.colorbar(im, ax=ax, extend='both',
-                                                ticks=ticks)
+                        if zmin == 0:
+                            cb = ax.figure.colorbar(im, ax=ax, extend='max',
+                                                    ticks=ticks)
+                        else:
+                            cb = ax.figure.colorbar(im, ax=ax, extend='both',
+                                                    ticks=ticks)
 
                 except (ZeroDivisionError, Warning):
                     raise rtp_exceptions.RTPZeroError(parameter, beam_num,


### PR DESCRIPTION
# Scope 

This PR changes the colour bar plotting for rtp, fan, grid and map plots where the colour map does not extend below zero. 
This is done by having an if statement around the colour bar plotting, if the vmin of the data is == 0 then only extend the top of the bar, if not then have both extended. 

I have not changed the code for contour colour bar in maps as the contours will always be centred at 0 so extend both ways regardless. 

**issue:** No issue made

## Approval

**Number of approvals:** 2

## Test

**matplotlib version**: 3.5.3
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt 
import pydarn

# RTP and Fan
file = "/Users/carley/Documents/data/20160120.1602.00.cly.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

a = pydarn.RTP.plot_summary(fitacf_data, beam_num=10,
                            range_estimation=pydarn.RangeEstimation.RANGE_GATE)
plt.show()

pydarn.Fan.plot_fan(fitacf_data, scan_index=50,
                    radar_label=True, lowlat=50, parameter='p_l')
plt.show()

# Grid Plot
grid_file = "/Users/carley/Documents/data/grids/20011220.8000.grid"
grid_data = pydarn.SuperDARNRead(grid_file).read_grid()
pydarn.Grid.plot_grid(grid_data, record=5, parameter = 'vel',
                      fov_color='grey')
plt.show()

# Convection Map
map_file = "/Users/carley/Documents/data/maps/20150310.n.map"
map_data = pydarn.SuperDARNRead().read_dmap(map_file)
pydarn.Maps.plot_mapdata(map_data,record=360, 
            parameter=pydarn.MapParams.FITTED_VELOCITY,
            lowlat=50)
plt.show()
```
![Screen Shot 2022-08-18 at 4 29 43 PM](https://user-images.githubusercontent.com/60905856/185507235-71c2aa8e-956e-4aa7-8986-941753aa5ac8.png)
<img width="629" alt="Screen Shot 2022-08-18 at 4 30 01 PM" src="https://user-images.githubusercontent.com/60905856/185507169-120c4c8a-9046-4473-8d11-138d08e374f9.png">
<img width="538" alt="Screen Shot 2022-08-18 at 4 30 15 PM" src="https://user-images.githubusercontent.com/60905856/185507182-22bd3889-9ea9-4da2-8c95-88703a94d062.png">
<img width="672" alt="Screen Shot 2022-08-18 at 4 32 00 PM" src="https://user-images.githubusercontent.com/60905856/185507200-8f63d2bd-3bc3-4499-8d07-cc72b898a3d0.png">

