### PR TITLE
BUG: Groundscatter fix for fan plots

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -327,7 +327,8 @@ class Fan():
             ax.pcolormesh(thetas, rs,
                           np.ma.masked_array(grndsct,
                                              ~grndsct.astype(bool)),
-                          norm=norm, cmap='Greys', transform=transform)
+                          norm=norm, cmap='Greys',
+                          transform=transform, zorder=3)
         if ccrs is None:
             azm = np.linspace(0, 2 * np.pi, 100)
             r, th = np.meshgrid(rs, azm)


### PR DESCRIPTION
# Scope 

This PR gives the groundscatter masked array a zorder of one above the full array of data for a fan plot. Previously the data was plotting over the groundscatter if groundscatter=True.

Develop branch now:
<img width="679" alt="Screen Shot 2022-08-26 at 11 58 12 AM" src="https://user-images.githubusercontent.com/60905856/186964883-0f070a85-a8f2-4f0e-9215-dae9f2d79f4f.png">

With this fix:
<img width="653" alt="Screen Shot 2022-08-26 at 11 57 44 AM" src="https://user-images.githubusercontent.com/60905856/186964903-3cecdc7b-c486-433b-b832-019bc7036155.png">


**issue:**

## Approval

**Number of approvals:** 1, only a one liner.

## Test

**matplotlib version**: 3.5.3
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt
import pydarn
file='/Users/carley/Documents/data/20150308.1400.03.cly.fitacf'
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()
pydarn.Fan.plot_fan(fitacf_data, scan_index=5, lowlat=50, groundscatter=False)
plt.show()
```
Gives the second plot above. 
