### PR TITLE
FIX: mpl axes_grid depreciation fix

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -32,7 +32,7 @@ import warnings
 
 from enum import Enum
 from matplotlib import ticker, cm, colors
-from mpl_toolkits.axes_grid.inset_locator import InsetPosition
+from mpl_toolkits.axes_grid1.inset_locator import InsetPosition
 from scipy import special
 from typing import List
 


### PR DESCRIPTION
# Scope 

This fixes the depreciation of the axes_grid module of matplotlib -appears to have just changed to axes_grid1.

**issue:** #284 

## Approval

**Number of approvals:** 1 (1 liner)

## Test

**matplotlib version**: tested on 3.6.0 (new version that won't work before), 3.5.3 and 3.3.4 (lowest compatible version with pyDARN)
**Note testers: please indicate what version of matplotlib you are using**

imports correctly:
`import pydarn`


You can check that the map plots are still working with:
```python
import matplotlib.pyplot as plt
import pydarn
map_file = "/Users/carley/Documents/data/maps/20170113.s.map"
map_data = pydarn.SuperDARNRead().read_dmap(map_file)
pydarn.Maps.plot_mapdata(map_data,record=360, 
            parameter=pydarn.MapParams.FITTED_VELOCITY,
            lowlat=30, color_vectors=False,
            contour_fill=True, coastline=True)
plt.show()
```
