### PR TITLE
FIX: Remove *ymax* set values for summary plots

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -1120,14 +1120,7 @@ class RTP():
             # plot range-time
             else:
                 # Current standard is to only have groundscatter
-                # on the velocity plot. This may change in the future.
-                if range_estimation == RangeEstimation.SLANT_RANGE:
-                    ymax = 3517.5
-                elif range_estimation == RangeEstimation.GSMR or \
-                        range_estimation == RangeEstimation.HALF_SLANT:
-                    ymax = 3517.5/2
-                else:
-                    ymax = 75
+                # on the velocity plot. 
                 if groundscatter and axes_parameters[i] == 'v':
                     grndflg = True
                 else:
@@ -1148,7 +1141,7 @@ class RTP():
                                                 axes_parameters[i]][0],
                                             zmax=boundary_ranges[
                                                 axes_parameters[i]][1],
-                                            ymax=ymax, yspacing=500,
+                                            yspacing=500,
                                             background=background,
                                             range_estimation=range_estimation,
                                             **kwargs)


### PR DESCRIPTION
# Scope 

This PR removes some code that set ymax values to 75 range gates or equavalent in summary plots. *ymax* now works as a kwarg to read through to *plot_range_time* and the user can now set values of ymax for all range time plots. They all must be the same ymax value though. Not setting ymax will default to min/max values of the data as written in *plt_range_time*.

Be nice to get this into the current release branch too.

**issue:** to close #288 

## Approval

**Number of approvals:** 1 is fine, 2 would be nice. Just removal of some code. 

## Test

**matplotlib version**: 3.6.2
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt 
import pydarn

file = "/Users/carley/Documents/data/20160120.1602.00.cly.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()
a = pydarn.RTP.plot_summary(fitacf_data, beam_num=10,
                            range_estimation=pydarn.RangeEstimation.RANGE_GATE,
                            ymax=25)
plt.show()
```
Please test using the SLANT_RANGE, HALF_SLANT, GSMR and RANGE_GATE values with various ymax values, including using no ymax kw. 

This returns: 
![Screen Shot 2022-11-09 at 11 44 08 AM](https://user-images.githubusercontent.com/60905856/200902636-9b419e41-5b5c-4c79-8bea-0af75bb26b20.png)
