### PR TITLE
FIX: hdw repo not installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import sys
 import warnings
 
 from os import path
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 from setuptools.command.install import install, orig
 from setuptools.command.develop import develop
 from glob import glob
@@ -83,7 +83,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'],
     python_requires='>=3.6',
-    packages=find_packages(['pydarn/utils/hdw'],exclude=['docs', 'test']),
+    packages=find_namespace_packages(exclude=['docs', 'test']),
     author="SuperDARN Data Visualization Working Group",
     # used to import the logging config file into pydarn.
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'],
     python_requires='>=3.6',
-    packages=find_packages(exclude=['docs', 'test']),
+    packages=find_packages(['pydarn/utils/hdw'],exclude=['docs', 'test']),
     author="SuperDARN Data Visualization Working Group",
     # used to import the logging config file into pydarn.
     include_package_data=True,


### PR DESCRIPTION
# Scope 

This PR is an attempt to fix the hdw repo not installing on new pip installations. I *think* this will fix it, but I will need to try it out on testpypi first I think. In fixing this, another depreciation warning for pip is showing saying that setup.py install is going to be depreciated *this may or may not be an issue for us, it's very unclear what is happening with that*.

**issue:** to close #292 

## Approval

**Number of approvals:** 2

## Test

**matplotlib version**: NA
**Note testers: please indicate what version of matplotlib you are using**

I will update here when I try to put it on testpypi, in the meantime you can try doing 
`pip3 install git+https://github.com/superdarn/pydarn@fix/hdw-repo`
Installing this way didn't have a issue with the hdw repo before so it should just work anyway.

