### PR TITLE
EHN: Single Beam Options

### DIFF
--- a/docs/user/fan.md
+++ b/docs/user/fan.md
@@ -117,6 +117,7 @@ Here is a list of all the current options than can be used with `plot_fan`
 | projs=(Projs)                 | Projections to plot the data on top of                                                                  |
 | colorbar_label=(string)       | Label that appears next to the color bar, requires colorbar to be True                                  |
 | coastline=(bool)              | Plots outlines of coastlines below data (Uses Cartopy)                                                  |
+| beam=(int)                    | Only plots data/outline of specified beam (default: None)                                               |
 | kwargs **                     | Axis Polar settings. See [polar axis](axis.md)                                                          |
 
 

--- a/docs/user/fov.md
+++ b/docs/user/fov.md
@@ -59,6 +59,7 @@ Here is a list of all the current options than can be used with `plot_fov`
 | radar_location=(bool)   | Places a dot in the plot representing the radar location (default: True)                                |
 | radar_label=(bool)      | Places the radar 3-letter abbreviation next to the radar location                                       |
 | coastline=(bool)        | Plots outlines of coastlines below FOV (Uses Cartopy)                                                   |
+| beam=(int)              | Only plots outline/fill of specified beam (default: None)                                               |
 | kwargs **               | Axis Polar settings. See [polar axis](axis.md)                                                          |
 
 To plot based on hemisphere or selection of radars, here is an example plotting North hemisphere radars with selected SuperDARN Canada radars colored as green, note that the axes object (ax) needs to be updated inside to loop to plot multiple FOV:


### PR DESCRIPTION
# Scope 

This PR contains an addition to the `fan.py` module that allows for the option `beam` to be passed to the fov and fan plotting functions. This allows the user to plot more specific data, or make diagrams with beams in fov.  The examples below use a file that is using camping beam,  which is a good use case/option to plot single beams. Default for `beam` is `None`. Docs updated. 

**issue:** #294 

## Approval

**Number of approvals:** 2 test and code review

## Test

**matplotlib version**: 3.6.3
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt
import pydarn
import datetime as dt

file = "/Users/carley/Documents/data/20150308.1400.03.cly.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

# FOV plot highlighting geographic and magnetic
_, _ , ax, ccrs = pydarn.Fan.plot_fov(fitacf_data[0]['stid'], dt.datetime(2015,3,8,14,10), beam=10, grid=True, fov_color='red',coords=pydarn.Coords.GEOGRAPHIC ,projs=pydarn.Projs.GEO, coastline=True, lowlat=50)
_, _, ax, ccrs = pydarn.Fan.plot_fov(fitacf_data[0]['stid'], dt.datetime(2015,3,8,14,10), ax=ax, ccrs=ccrs, beam=4, grid=True, fov_color='blue',ranges=[30,60], coords=pydarn.Coords.GEOGRAPHIC ,projs=pydarn.Projs.GEO)
_, _, ax, ccrs = pydarn.Fan.plot_fov(fitacf_data[0]['stid'], dt.datetime(2015,3,8,14,10), ax=ax, ccrs=ccrs, coords=pydarn.Coords.GEOGRAPHIC ,projs=pydarn.Projs.GEO)
plt.show()

_, _, ax, _ = pydarn.Fan.plot_fov(fitacf_data[0]['stid'], dt.datetime(2015,3,8,14,10), beam=10, grid=True, fov_color='red', coastline=True, lowlat=50)
_, _, ax, _ = pydarn.Fan.plot_fov(fitacf_data[0]['stid'], dt.datetime(2015,3,8,14,10), ax=ax, beam=4, grid=True, fov_color='blue',ranges=[30,60])
_, _, ax, _ = pydarn.Fan.plot_fov(fitacf_data[0]['stid'], dt.datetime(2015,3,8,14,10), ax=ax)
plt.show()

# Fan plot with specific data in geo and mag
_, _, ax, ccrs = pydarn.Fan.plot_fov(fitacf_data[0]['stid'], dt.datetime(2015,3,8,14,10), coastline=True, lowlat=50, coords=pydarn.Coords.GEOGRAPHIC ,projs=pydarn.Projs.GEO)
pydarn.Fan.plot_fan(fitacf_data, scan_index=dt.datetime(2015,3,8,14,10), beam=10, boundary=True,radar_label=True, groundscatter=True, ax=ax, colorbar=False, coords=pydarn.Coords.GEOGRAPHIC ,projs=pydarn.Projs.GEO)
pydarn.Fan.plot_fan(fitacf_data, scan_index=dt.datetime(2015,3,8,14,10), beam=4, ranges=[30,60], boundary=True, radar_label=True, groundscatter=True, ax=ax, coords=pydarn.Coords.GEOGRAPHIC ,projs=pydarn.Projs.GEO)
plt.show()

_, _, ax, _ = pydarn.Fan.plot_fov(fitacf_data[0]['stid'], dt.datetime(2015,3,8,14,10), coastline=True, lowlat=50)
pydarn.Fan.plot_fan(fitacf_data, scan_index=dt.datetime(2015,3,8,14,10), beam=10, boundary=True,radar_label=True, groundscatter=True, ax=ax, colorbar=False)
pydarn.Fan.plot_fan(fitacf_data, scan_index=dt.datetime(2015,3,8,14,10), beam=4, ranges=[30,60], boundary=True, radar_label=True, groundscatter=True, ax=ax)
plt.show()
```
The above code, produces the following plots:

<img width="611" alt="Screenshot 2023-02-06 at 12 48 38 PM" src="https://user-images.githubusercontent.com/60905856/217058998-2c4dc18e-7c5d-4efc-9047-38ec328b108e.png">
<img width="476" alt="Screenshot 2023-02-06 at 12 48 51 PM" src="https://user-images.githubusercontent.com/60905856/217059001-9896869e-65c3-4e2b-a252-869fc2f19adf.png">
<img width="900" alt="Screenshot 2023-02-06 at 12 49 06 PM" src="https://user-images.githubusercontent.com/60905856/217059026-f3fc6240-f657-4788-b0b6-69cc9a7d56d0.png">
<img width="681" alt="Screenshot 2023-02-06 at 12 49 23 PM" src="https://user-images.githubusercontent.com/60905856/217059031-1192ee8c-3411-417b-8373-7aaba9b63d71.png">


