### PR TITLE
EHN: Adding New Iceland Radars

### DIFF
--- a/pydarn/utils/superdarn_radars.py
+++ b/pydarn/utils/superdarn_radars.py
@@ -13,6 +13,7 @@
 # Modifications:
 # 2022-02-11 MTS USASK updated the _HDW_info class to take in
 #            the hardware format
+# 2023-01-21 CJM Added ICE and ICW defaults and hdw link
 """
 This module contains SuperDARN radar information
 """
@@ -490,6 +491,10 @@ class SuperDARNRadars():
                          Hemisphere.North, 110, read_hdw_file('hok')),
               41: _Radar('Hokkaido West', 'Nagoya University',
                          Hemisphere.North, 110, read_hdw_file('hkw')),
+              211: _Radar('Iceland East', 'Dartmouth College',
+                         Hemisphere.North, 100, read_hdw_file('ice')),
+              210: _Radar('Iceland West', 'Dartmouth College',
+                         Hemisphere.North, 100, read_hdw_file('icw')),
               64: _Radar('Inuvik', 'University of Saskatchewan',
                          Hemisphere.North, 75, read_hdw_file('inv')),
               50: _Radar('Jiamusi East radar',


### PR DESCRIPTION
# Scope 

This PR includes the new ICE and ICW radars. 
Will wait for merge in hdw repo and then will need to point the hdw link to a newer commit in the hdw repo, but this PR includes the changes needed in the code.
Considering waiting doing the patch release to include this update too, as it includes more changes in the hdw repo?

**issue:** close #300 

## Approval

**Number of approvals:** 2

## Test
Can't test properly until the PR in hdw is merged. 
You can grab those files from the hdw repo and add them to your pydarn/utils/hdw directory if you wanted to test just these new lines of code, but we need to test the hdw repo commit anyway later.

## Update
hdw repo now contains ICE and ICW, I have updated the submodule, so will convert to ready!
Make sure when installing that you get the new hdw files in the correct directory, you won't have any data to plot them yet, but you should be able to plot a FOV for both radars as below:

```python
import pydarn
from datetime import datetime
import matplotlib.pyplot as plt 

plt.figure(figsize=(8,8))
_,_,ax1,ccrs1=pydarn.Fan.plot_fov(211, datetime(2023, 1, 24, 0, 0), radar_location=True, radar_label=True, lowlat= 30, boundary=True,fov_color='red',coords=pydarn.Coords.GEOGRAPHIC ,projs=pydarn.Projs.GEO, coastline=True)
pydarn.Fan.plot_fov(210, datetime(2023, 1, 24, 0, 0), radar_location=True, ccrs=ccrs1,  ax=ax1, boundary=True, fov_color='blue',coords=pydarn.Coords.GEOGRAPHIC ,projs=pydarn.Projs.GEO)
plt.show()
```

<img width="745" alt="Screenshot 2023-02-21 at 4 07 48 PM" src="https://user-images.githubusercontent.com/60905856/220469818-04acf81f-52f9-40fc-9f39-34697b2a9922.png">
