### PR TITLE
FIX: Correct where partial record check occurs in Grid plot

### DIFF
--- a/pydarn/plotting/grid.py
+++ b/pydarn/plotting/grid.py
@@ -168,12 +168,12 @@ class Grid():
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            # Check for partial record and/or read in positions
-            try:
-                data_lons = dmap_data[record]['vector.mlon']
-                data_lats = dmap_data[record]['vector.mlat']
-            except KeyError:
-                raise plot_exceptions.PartialRecordsError('vector.mlon')
+            # Check for partial records
+            if all(dmap_data[record]['nvec'] == 0) :
+                raise plot_exceptions.PartialRecordsError('~all vectors~')
+    
+            data_lons = dmap_data[record]['vector.mlon']
+            data_lats = dmap_data[record]['vector.mlat']
 
             # Hemisphere is not found in grid files so take from latitudes
             hemisphere = Hemisphere(np.sign(

--- a/pydarn/plotting/grid.py
+++ b/pydarn/plotting/grid.py
@@ -168,6 +168,13 @@ class Grid():
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
+            # Check for partial record and/or read in positions
+            try:
+                data_lons = dmap_data[record]['vector.mlon']
+                data_lats = dmap_data[record]['vector.mlat']
+            except KeyError:
+                raise plot_exceptions.PartialRecordsError('vector.mlon')
+
             # Hemisphere is not found in grid files so take from latitudes
             hemisphere = Hemisphere(np.sign(
                                     dmap_data[record]['vector.mlat'][0]))
@@ -181,11 +188,6 @@ class Grid():
                 _, coord_lons, ax, ccrs =\
                         Fan.plot_fov(stid, date, ax=ax, ccrs=ccrs,
                                      coords=coords, projs=projs, **kwargs)
-            try:
-                data_lons = dmap_data[record]['vector.mlon']
-                data_lats = dmap_data[record]['vector.mlat']
-            except KeyError:
-                raise plot_exceptions.PartialRecordsError('vector.mlon')
 
             if coords != Coords.GEOGRAPHIC and projs == Projs.GEO:
                 raise plot_exceptions.NotImplemented(


### PR DESCRIPTION
# Scope 

This PR fixes the bug where if a partial record is given to the grid plotting method, an error in the code will show instead of the warning about partial records. 

**issue:** to close #310 

## Approval

**Number of approvals:** 1

## Test

**matplotlib version**: 3.7.1
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt 
import datetime as dt
import pydarn

#grid_file = "/Users/carley/Documents/data/grids/20210101.0001.00.zho.grd"
grid_file = "/Users/carley/Documents/data/grids/20210101.0400.00.jme.grd"
grid_data = pydarn.SuperDARNRead(grid_file).read_grid()

print(grid_data[30])
pydarn.Grid.plot_grid(grid_data, record=30)

plt.show()
```
when running for the JME file you should find that the partial records warning shows, not an error:
```
pyDARN could not plot the following due to the following field vector.mlon was missing. This may be due to partialrecords created in RST (data processing software for SuperDARN)
```
Grid files to test below:
[grid.zip](https://github.com/SuperDARN/pydarn/files/11296966/grid.zip)
