### PR TITLE
FIX: Bug in plotting when data out of time order

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -288,8 +288,24 @@ class RTP():
                 break
             if x != []:
                 # 60.0 seconds in a minute
-                delta_diff_time = (rec_time - x[-1])
+                delta_diff_time = abs(rec_time - x[-1])
                 diff_time = delta_diff_time.seconds/60.0
+                # Abs added above as some files have data out of order
+                # abs stops the code from hanging and plotting over a day
+                # of white space, but user needs to be warned that the
+                # output may be incorrect
+                if (rec_time - x[-1]) < timedelta(0):
+                    # warnings are turned off for summary plots so
+                    # for now print to console
+                    # May be repeated, but will show what records are out
+                    # of time order by doing so to help user
+                    print("Please be aware that the data for timestamp {}"
+                          " contains a record that is not"
+                          " in time order. As such the plot of the"
+                          " data may not be correct, you can solve"
+                          " this by sorting the data stream by date"
+                          " before plotting.".format(rec_time))
+
 
             # separation roughly 2 minutes
             if diff_time > 2.0:


### PR DESCRIPTION
# Scope 

This PR stops the code from hanging when plotting R-T plots on data that is slightly out of time order.
This issue was found with data from HOK for 2016-01-16 where two records are written for the same beam and channel with milliseconds difference, but some records saw that the first occurred after the second record. It's not in our remit to decide if these data should be in the distribution or not, I'm just fixing it so that a warning will show, and the summary plot will not hang trying to plot for 6 hours. 

In the future we should also have a discussion on what we want to do with warnings as for summary plots they are switched off and due to this I had to use a print statement instead of the warnings library for this warning- this is out of scope for this PR but something that needs work done in the future as I think it's a overarching issue in the RTP module.

**issue:** No issue

## Approval

**Number of approvals:** 1

## Test

**matplotlib version**: 
**Note testers: please indicate what version of matplotlib you are using**

```python
import pydarn
import glob
import bz2
import matplotlib.pyplot as plt

full_path = '/Users/carley/Desktop/data/**'
file_paths= glob.glob(full_path)
file_paths.sort()

data = []
for i in file_paths:
    fitacf_file = i
    with bz2.open(fitacf_file) as fp:
        fitacf_stream = fp.read()
        reader = pydarn.SuperDARNRead(fitacf_stream, True)
        records = reader.read_fitacf()
        data += records

a = pydarn.RTP.plot_summary(data, beam_num=5, range_estimation=pydarn.RangeEstimation.RANGE_GATE)
plt.show()
```

You should get a plot and some text in your console that reads:
```
Please be aware that the data for timestamp 2016-01-16 02:00:21.729949 contains a record that is not in time order. As such the plot of the data may not be correct, you can solve this by sorting the data stream by date before plotting.
```

You should not see this statement if you are using 99.9% of fitacf files, currently this warning will show up for the data provided below:
[20160116.0002.00.hok.fitacf.bz2.zip](https://github.com/SuperDARN/pydarn/files/11355223/20160116.0002.00.hok.fitacf.bz2.zip)
If you try to use develop branch or main, you will find that this data make the code hang for a long time whilst trying to process negative timedeltas.
