### PR TITLE
EHN: Elevation Default to 'inferno' and Fix `cm.get_cmap` Depreciation

### DIFF
--- a/pydarn/plotting/color_maps.py
+++ b/pydarn/plotting/color_maps.py
@@ -1,30 +1,30 @@
-import matplotlib.colors as mcol
+import matplotlib
+import packaging
+
+if packaging.version.parse(matplotlib.__version__) < \
+        packaging.version.parse('3.7.0'):
+    from matplotlib import cm
+else:
+    from matplotlib import colormaps as cm
 
 
 class PyDARNColormaps():
-    PYDARN_VELOCITY =\
-            mcol.LinearSegmentedColormap.from_list("pydarn_velocity",
-                                                   ["darkred", "r",
-                                                    'pink', "b", "darkblue"])
+    PYDARN_INFERNO = cm.get_cmap('inferno')
+    PYDARN_PLASMA = cm.get_cmap('plasma')
+    PYDARN_PLASMA_R = cm.get_cmap('plasma_r')
+    PYDARN_VELOCITY = matplotlib.colors.LinearSegmentedColormap.from_list(
+                        "pydarn_velocity", ["darkred", "r", 'pink', "b",
+                                            "darkblue"])
 
-    PYDARN_VIRIDIS =\
-        mcol.LinearSegmentedColormap.from_list("pydarn_viridis",
-                                               ["indigo", "midnightblue",
-                                                "navy", "mediumblue",
-                                                "teal",
-                                                "mediumseagreen",
-                                                "limegreen", "yellowgreen",
-                                                "yellow", "gold"])
+    PYDARN_VIRIDIS = matplotlib.colors.LinearSegmentedColormap.from_list(
+                        "pydarn_viridis", ["indigo", "midnightblue",
+                                           "navy", "mediumblue",
+                                           "teal", "mediumseagreen",
+                                           "limegreen", "yellowgreen",
+                                           "yellow", "gold"])
 
-    PYDARN =\
-        mcol.LinearSegmentedColormap.from_list("pydarn", ["midnightblue",
-                                                          "darkblue",
-                                                          "mediumblue",
-                                                          "rebeccapurple",
-                                                          "purple",
-                                                          "darkmagenta",
-                                                          "mediumvioletred",
-                                                          "crimson", "red",
-                                                          "orangered",
-                                                          "darkorange",
-                                                          "orange", "gold"])
+    PYDARN = matplotlib.colors.LinearSegmentedColormap.from_list("pydarn",
+                ["midnightblue", "darkblue", "mediumblue", "rebeccapurple",
+                 "purple", "darkmagenta", "mediumvioletred", "crimson", "red",
+                 "orangered", "darkorange", "orange", "gold"])
+

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -261,8 +261,7 @@ class Fan():
         if cmap is None:
             cmap = {'p_l': 'plasma', 'v': PyDARNColormaps.PYDARN_VELOCITY,
                     'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
-
-                    'elv': PyDARNColormaps.PYDARN}
+                    'elv': 'inferno'}
             cmap = plt.cm.get_cmap(cmap[parameter])
 
         # Set background to transparent - avoids carry over

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -40,7 +40,7 @@ import datetime as dt
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib import ticker, cm, colormaps, colors
+from matplotlib import ticker, cm, colors
 from typing import List, Union
 
 # Third party libraries
@@ -259,10 +259,11 @@ class Fan():
         # Colour table and max value selection depending on parameter plotted
         # Load defaults if none given
         if cmap is None:
-            cmap = {'p_l': 'plasma', 'v': PyDARNColormaps.PYDARN_VELOCITY,
+            cmap = {'p_l': PyDARNColormaps.PYDARN_PLASMA,
+                    'v': PyDARNColormaps.PYDARN_VELOCITY,
                     'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
-                    'elv': 'inferno'}
-            cmap = plt.colormaps.get_cmap(cmap[parameter])
+                    'elv': PyDARNColormaps.PYDARN_INFERNO}
+            cmap = cmap[parameter]
 
         # Set background to transparent - avoids carry over
         # does not interfere with the fov color if chosen

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -40,7 +40,7 @@ import datetime as dt
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib import ticker, cm, colors
+from matplotlib import ticker, cm, colormaps, colors
 from typing import List, Union
 
 # Third party libraries
@@ -262,7 +262,7 @@ class Fan():
             cmap = {'p_l': 'plasma', 'v': PyDARNColormaps.PYDARN_VELOCITY,
                     'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
                     'elv': 'inferno'}
-            cmap = plt.cm.get_cmap(cmap[parameter])
+            cmap = plt.colormaps.get_cmap(cmap[parameter])
 
         # Set background to transparent - avoids carry over
         # does not interfere with the fov color if chosen

--- a/pydarn/plotting/grid.py
+++ b/pydarn/plotting/grid.py
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import warnings
 
-from matplotlib import ticker, cm, colors
+from matplotlib import ticker, cm, colormaps, colors
 from typing import List
 
 # Third party libraries
@@ -238,7 +238,7 @@ class Grid():
                         'vector.vel.median': 'plasma_r',
                         'vector.wdt.median':
                         PyDARNColormaps.PYDARN_VIRIDIS}
-                cmap = plt.cm.get_cmap(cmap[parameter])
+                cmap = plt.colormaps.get_cmap(cmap[parameter])
 
             # Setting zmin and zmax
             defaultzminmax = {'vector.pwr.median': [0, 50],

--- a/pydarn/plotting/grid.py
+++ b/pydarn/plotting/grid.py
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import warnings
 
-from matplotlib import ticker, cm, colormaps, colors
+from matplotlib import ticker, cm, colors
 from typing import List
 
 # Third party libraries
@@ -234,11 +234,10 @@ class Grid():
             # Colour table and max value selection depending on
             # parameter plotted Load defaults if none given
             if cmap is None:
-                cmap = {'vector.pwr.median': 'plasma',
-                        'vector.vel.median': 'plasma_r',
-                        'vector.wdt.median':
-                        PyDARNColormaps.PYDARN_VIRIDIS}
-                cmap = plt.colormaps.get_cmap(cmap[parameter])
+                cmap = {'vector.pwr.median': PyDARNColormaps.PYDARN_PLASMA,
+                        'vector.vel.median': PyDARNColormaps.PYDARN_PLASMA_R,
+                        'vector.wdt.median': PyDARNColormaps.PYDARN_VIRIDIS}
+                cmap = cmap[parameter]
 
             # Setting zmin and zmax
             defaultzminmax = {'vector.pwr.median': [0, 50],

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -32,7 +32,7 @@ import numpy as np
 import warnings
 
 from enum import Enum
-from matplotlib import ticker, cm, colormaps, colors
+from matplotlib import ticker, cm, colors
 from mpl_toolkits.axes_grid1.inset_locator import InsetPosition
 from scipy import special
 from typing import List
@@ -164,12 +164,12 @@ class Maps():
         date = time2datetime(dmap_data[record])
 
         if cmap is None:
-            cmap = {MapParams.FITTED_VELOCITY: 'plasma_r',
-                    MapParams.MODEL_VELOCITY: 'plasma_r',
-                    MapParams.RAW_VELOCITY: 'plasma_r',
-                    MapParams.POWER: 'plasma',
+            cmap = {MapParams.FITTED_VELOCITY: PyDARNColormaps.PYDARN_PLASMA_R,
+                    MapParams.MODEL_VELOCITY: PyDARNColormaps.PYDARN_PLASMA_R,
+                    MapParams.RAW_VELOCITY: PyDARNColormaps.PYDARN_PLASMA_R,
+                    MapParams.POWER: PyDARNColormaps.PYDARN_PLASMA,
                     MapParams.SPECTRAL_WIDTH: PyDARNColormaps.PYDARN_VIRIDIS}
-            cmap = plt.colormaps.get_cmap(cmap[parameter])
+            cmap = cmap[parameter]
         # Setting zmin and zmax
         defaultzminmax = {MapParams.FITTED_VELOCITY: [0, 1000],
                           MapParams.MODEL_VELOCITY: [0, 1000],

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -32,7 +32,7 @@ import numpy as np
 import warnings
 
 from enum import Enum
-from matplotlib import ticker, cm, colors
+from matplotlib import ticker, cm, colormaps, colors
 from mpl_toolkits.axes_grid1.inset_locator import InsetPosition
 from scipy import special
 from typing import List
@@ -169,7 +169,7 @@ class Maps():
                     MapParams.RAW_VELOCITY: 'plasma_r',
                     MapParams.POWER: 'plasma',
                     MapParams.SPECTRAL_WIDTH: PyDARNColormaps.PYDARN_VIRIDIS}
-            cmap = plt.cm.get_cmap(cmap[parameter])
+            cmap = plt.colormaps.get_cmap(cmap[parameter])
         # Setting zmin and zmax
         defaultzminmax = {MapParams.FITTED_VELOCITY: [0, 1000],
                           MapParams.MODEL_VELOCITY: [0, 1000],

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -131,8 +131,6 @@ def axis_polar(date, ax: object = None, lowlat: int = 30,
         # Tick labels will depend on coordinate system
         ax.set_xticklabels(['00', '', '06', '', '12', '', '18', ''])
         ax.set_theta_zero_location("S")
-        if grid_lines:
-            ax.grid()
 
     if coastline is True:
         if cartopyInstalled is False:

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -131,6 +131,8 @@ def axis_polar(date, ax: object = None, lowlat: int = 30,
         # Tick labels will depend on coordinate system
         ax.set_xticklabels(['00', '', '06', '', '12', '', '18', ''])
         ax.set_theta_zero_location("S")
+        if grid_lines:
+            ax.grid()
 
     if coastline is True:
         if cartopyInstalled is False:

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -30,7 +30,7 @@ import numpy as np
 import warnings
 
 from datetime import datetime, timedelta
-from matplotlib import dates, colors, cm, ticker
+from matplotlib import dates, colors, colormaps, ticker
 from typing import List
 
 from pydarn import (RangeEstimation, check_data_type,
@@ -154,7 +154,7 @@ class RTP():
         colorbar_label: str
             the label that appears next to the color bar
             Default: ''
-        cmap: str or matplotlib.cm
+        cmap: str or matplotlib.colormaps
             matplotlib colour map
             https://matplotlib.org/tutorials/colors/colormaps.html
             Default: PyDARNColormaps.PYDARN_VELOCITY
@@ -201,7 +201,7 @@ class RTP():
             matplotlib object from pcolormesh
         cb: matplotlib.colorbar
             matplotlib color bar
-        cmap: matplotlib.cm
+        cmap: matplotlib.colormaps
             matplotlib color map object
         time_axis: list
             list representing the x-axis datetime objects
@@ -411,14 +411,14 @@ class RTP():
                           " options".format(zmax))
         norm = norm(zmin, zmax)
         if isinstance(cmap, str):
-            cmap = cm.get_cmap(cmap)
+            cmap = colormaps.get_cmap(cmap)
         else:
             # need to do this as matplotlib 3.5 will
             # not all direct mutations of the object
-            cmaps = {'p_l': copy.copy(cm.get_cmap('plasma')),
+            cmaps = {'p_l': copy.copy(colormaps.get_cmap('plasma')),
                      'v': PyDARNColormaps.PYDARN_VELOCITY,
                      'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
-                     'elv': copy.copy(cm.get_cmap('inferno'))}
+                     'elv': copy.copy(colormaps.get_cmap('inferno'))}
             cmap = cmaps[parameter]
 
         # set the background color, this needs to happen to avoid

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -878,7 +878,7 @@ class RTP():
             dictionary of matplotlib color maps for the summary
             range time parameter plots.
             https://matplotlib.org/tutorials/colors/colormaps.html
-            Default: {'p_l': 'plasma',
+            Default: {'p_l': PyDARNColormaps.PYDARN_PLASMA,
                       'v': PyDARNColormaps.PYDARN_VELOCITY,
                       'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
                       'elv': 'inferno'}

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -418,7 +418,7 @@ class RTP():
             cmaps = {'p_l': copy.copy(cm.get_cmap('plasma')),
                      'v': PyDARNColormaps.PYDARN_VELOCITY,
                      'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
-                     'elv': PyDARNColormaps.PYDARN}
+                     'elv': copy.copy(cm.get_cmap('inferno'))}
             cmap = cmaps[parameter]
 
         # set the background color, this needs to happen to avoid
@@ -883,7 +883,7 @@ class RTP():
             Default: {'p_l': 'plasma',
                       'v': PyDARNColormaps.PYDARN_VELOCITY,
                       'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
-                      'elv': PyDARNColormaps.PYDARN}
+                      'elv': 'inferno'}
             note: to reverse the color just add _r to the string name
         lines: dict or str
             dictionary of time-series line colors.
@@ -982,7 +982,7 @@ class RTP():
         cmap = {'p_l': 'plasma',
                 'v': PyDARNColormaps.PYDARN_VELOCITY,
                 'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
-                'elv': PyDARNColormaps.PYDARN}
+                'elv': 'inferno'}
         if isinstance(cmaps, dict):
             cmap.update(cmaps)
         else:

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -30,7 +30,7 @@ import numpy as np
 import warnings
 
 from datetime import datetime, timedelta
-from matplotlib import dates, colors, colormaps, ticker
+from matplotlib import dates, colors, ticker
 from typing import List
 
 from pydarn import (RangeEstimation, check_data_type,
@@ -154,7 +154,7 @@ class RTP():
         colorbar_label: str
             the label that appears next to the color bar
             Default: ''
-        cmap: str or matplotlib.colormaps
+        cmap: matplotlib.colormaps
             matplotlib colour map
             https://matplotlib.org/tutorials/colors/colormaps.html
             Default: PyDARNColormaps.PYDARN_VELOCITY
@@ -410,15 +410,13 @@ class RTP():
                           "set zmin and zmax in the functions"
                           " options".format(zmax))
         norm = norm(zmin, zmax)
-        if isinstance(cmap, str):
-            cmap = colormaps.get_cmap(cmap)
-        else:
-            # need to do this as matplotlib 3.5 will
-            # not all direct mutations of the object
-            cmaps = {'p_l': copy.copy(colormaps.get_cmap('plasma')),
+        if cmap is None:
+            # If cmap is not None then cmap should have read in a
+            # colormap object already - error from matplotlib is instructive
+            cmaps = {'p_l': PyDARNColormaps.PYDARN_PLASMA,
                      'v': PyDARNColormaps.PYDARN_VELOCITY,
                      'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
-                     'elv': copy.copy(colormaps.get_cmap('inferno'))}
+                     'elv': PyDARNColormaps.PYDARN_INFERNO}
             cmap = cmaps[parameter]
 
         # set the background color, this needs to happen to avoid
@@ -979,10 +977,10 @@ class RTP():
             line.update(lines)
         else:
             line.update({k: lines for k, v in line.items()})
-        cmap = {'p_l': 'plasma',
+        cmap = {'p_l': PyDARNColormaps.PYDARN_PLASMA,
                 'v': PyDARNColormaps.PYDARN_VELOCITY,
                 'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
-                'elv': 'inferno'}
+                'elv': PyDARNColormaps.PYDARN_INFERNO}
         if isinstance(cmaps, dict):
             cmap.update(cmaps)
         else:

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -881,7 +881,7 @@ class RTP():
             Default: {'p_l': PyDARNColormaps.PYDARN_PLASMA,
                       'v': PyDARNColormaps.PYDARN_VELOCITY,
                       'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
-                      'elv': 'inferno'}
+                      'elv': PyDARNColormaps.PYDARN_INFERNO}
             note: to reverse the color just add _r to the string name
         lines: dict or str
             dictionary of time-series line colors.


### PR DESCRIPTION
# Scope 

This is a simple change of default colormap for the elevation data in rtp and fan plots.

EDIT: Whilst doing this change, Rem noticed a depreciation for cm.get_cmap which is not backwards compatible with older matplotlib versions. As a lot of servers cannot get the newer matplotlib versions I have left in a conditional import for the colormaps. To make this easier I have move any colormap 'get' processing to the color_maps.py module so that we only have to do one conditional import for cm/colormaps.

**issue:** #323 

## Approval

**Number of approvals:** 1 (Probably 2 now with changes)(and the okay from Bharat for this change next meeting!)

## Test

**matplotlib version**: 3.7.1
**Note testers: please indicate what version of matplotlib you are using**
Plot RTP/Summary and fan plots.
Make sure grids show up on fan plots.

```python
import matplotlib.pyplot as plt 
import pydarn

file = "/Users/carley/Documents/data/20131031.2201.00.sas.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

#pydarn.RTP.plot_summary(fitacf_data , beam_num=13)
pydarn.Fan.plot_fan(fitacf_data, parameter='elv', coastline=True, lowlat=60)
plt.show()
```
Old color map:

![Screenshot 2023-06-12 at 4 13 13 PM](https://github.com/SuperDARN/pydarn/assets/60905856/e0c879a3-a2fc-437d-8e25-ed0d73cb8c8e)
New color map:
![Screenshot 2023-06-12 at 4 12 10 PM](https://github.com/SuperDARN/pydarn/assets/60905856/852cadf3-7ca5-471b-9008-a138d8349187)
<img width="605" alt="Screenshot 2023-06-12 at 4 45 49 PM" src="https://github.com/SuperDARN/pydarn/assets/60905856/4faf0866-2161-41cc-8659-f9737f594aa3">

See comments for newer testing.

