### PR TITLE
FIX: Grid lines on Fan plots not showing

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -338,11 +338,6 @@ class Fan():
                                              ~grndsct.astype(bool)),
                           norm=norm, cmap='Greys',
                           transform=transform, zorder=3)
-        if ccrs is None:
-            azm = np.linspace(0, 2 * np.pi, 100)
-            r, th = np.meshgrid(rs, azm)
-            plt.plot(azm, r, color='k', ls='none')
-            plt.grid()
 
         if boundary:
             cls.plot_fov(stid=dmap_data[0]['stid'], date=date, ax=ax,

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -131,7 +131,6 @@ def axis_polar(date, ax: object = None, lowlat: int = 30,
         # Tick labels will depend on coordinate system
         ax.set_xticklabels(['00', '', '06', '', '12', '', '18', ''])
         ax.set_theta_zero_location("S")
-        ax.grid(zorder=3.0)
 
     if coastline is True:
         if cartopyInstalled is False:

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -131,6 +131,7 @@ def axis_polar(date, ax: object = None, lowlat: int = 30,
         # Tick labels will depend on coordinate system
         ax.set_xticklabels(['00', '', '06', '', '12', '', '18', ''])
         ax.set_theta_zero_location("S")
+        ax.grid(zorder=3.0)
 
     if coastline is True:
         if cartopyInstalled is False:


### PR DESCRIPTION
# Scope 

This PR fixes a bug where the plot grid lines on fan plots were not showing up. 
I have removed duplicate code that seems to mess up the grid plotting and added a zorder to the ax.grid() to give it a position on the plot. Zordering was added with the map plots but not checked against the fan plots. 

**issue:** No issue

## Approval

**Number of approvals:** 1 quick fix

## Test

**matplotlib version**: 3.7.1
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt 
import pydarn

file = "/Users/carley/Documents/data/20131031.2201.00.sas.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

ax, _,_,_,_ = pydarn.Fan.plot_fan(fitacf_data, parameter='elv', coastline=True, lowlat=60)
plt.show()
```
<img width="627" alt="Screenshot 2023-06-14 at 8 19 49 AM" src="https://github.com/SuperDARN/pydarn/assets/60905856/d274c908-7732-4c15-9ae9-a46de436703e">


If you get a chance have a look at map plots to make sure the grid lines are where you expect.

