### PR TITLE
DEP: Removed checks when using read_dmap

### DIFF
--- a/pydarn/io/superdarn_io.py
+++ b/pydarn/io/superdarn_io.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2020 SuperDARN Canada, University of Saskatchewan
 # Author: Marina Schmidt
+# Modifications:
+# 20230623 - CJM - Removed checks for read_dmap, will read in any dmap
 
 import bz2
 import pydarnio
@@ -51,15 +53,7 @@ class SuperDARNRead(pydarnio.SDarnRead):
 
         try:
             # Check which file type it is
-            if 'rawacf' in filename:
-                data = self.read_rawacf()
-            elif 'fitacf' in filename:
-                data = self.read_fitacf()
-            elif 'iqdat' in filename:
-                self.read_iqdat()
-            # if not noticeable then just read the file
-            else:
-                data = self.read_records()
+            data = self.read_records()
         except Exception as err:
             # sometimes files might fail due to issues with
             # the specific reading methods. This is not a pyDARN
@@ -67,8 +61,9 @@ class SuperDARNRead(pydarnio.SDarnRead):
             # then make an issue on pyDARNio
             print(err)
             print("..... Will try to read DMap file with read_dmap")
-            print(" IF THIS FAILS please make an issue on pyDARNio, not "
-                  "pyDARN's issue")
+            print(" IF THIS FAILS please make an issue on the pyDARNio"
+                  " GitHub repository:"
+                  " https://github.com/SuperDARN/pyDARNio/issues")
             data = self.read_records
         return data
 


### PR DESCRIPTION
# Scope 

This PR will allow read_dmap to read in without issue any DMap formatted file. Some files fail checks when using read_fitacf etc. but can possibly still be plotted as the data required for plotting is there. This is obviously something up to the discretion of the user, and as default we will tell people to use the read_filetype version of reading primarily.

**issue:** No issue made

## Approval

**Number of approvals:** 1
## Test

**matplotlib version**: 3.7.1
**Note testers: please indicate what version of matplotlib you are using**

```python
import pydarn

fit_file = "/Users/carley/Documents/data/20180101.0000.01.rkn.fitacf"
fit_data = pydarn.SuperDARNRead(fit_file).read_fitacf()
print(fit_data[0].keys())

fit_data2 = pydarn.SuperDARNRead(fit_file).read_dmap(fit_file)
print(fit_data2[0].keys())

raw_file = "/Users/carley/Documents/data/rawacf/20200713.0200.06.rkn.rawacf"
raw_data = pydarn.SuperDARNRead(raw_file).read_rawacf()
print(raw_data[0].keys())

raw_data2 = pydarn.SuperDARNRead().read_dmap(raw_file)
print(raw_data2[0].keys())

map_file = "/Users/carley/Documents/data/maps/20210101.n.map"
map_data = pydarn.SuperDARNRead(map_file).read_map()
print(map_data[0].keys())

map_data2 = pydarn.SuperDARNRead().read_dmap(map_file)
print(map_data2[0].keys())
```
Should print two sets of keys for each file type, you can test by plotting with both outcomes, there's also grid data but that wasn't included in the original if statement anyway so should work the same. 
