### PR TITLE
EHN: Summary plot defaults - change default Nave line to blue and watermark to False

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -24,7 +24,6 @@
 """
 Range-Time Parameter (aka Intensity) plots
 """
-import copy
 import matplotlib.pyplot as plt
 import numpy as np
 import warnings
@@ -305,7 +304,6 @@ class RTP():
                           " data may not be correct, you can solve"
                           " this by sorting the data stream by date"
                           " before plotting.".format(rec_time))
-
 
             # separation roughly 2 minutes
             if diff_time > 2.0:
@@ -966,7 +964,7 @@ class RTP():
         color = {'noise.search': 'k',
                  'noise.sky': 'k',
                  'tfreq': 'k',
-                 'nave': 'k'}
+                 'nave': 'b'}
 
         if isinstance(line_color, dict):
             color.update(line_color)
@@ -1096,7 +1094,8 @@ class RTP():
                                                  **kwargs)
                         second_ax.set_xticklabels([])
                         second_ax.set_ylabel(labels[i][1], rotation=0,
-                                             labelpad=25)
+                                             labelpad=25, color=color[
+                                                axes_parameters[i][1]])
                         second_ax.\
                             axhline(y=boundary_ranges[axes_parameters[i][1]][0]
                                     + 0.8, xmin=1.07, xmax=1.13,
@@ -1107,6 +1106,14 @@ class RTP():
                             set_ylim(boundary_ranges[axes_parameters[i][1]][0],
                                      boundary_ranges[axes_parameters[i][1]][1])
                         second_ax.yaxis.set_label_coords(1.1, 0.7)
+                        # Set color of second axis
+                        second_ax.spines["right"].set_edgecolor(color=color[
+                                                    axes_parameters[i][1]])
+                        second_ax.tick_params(axis='y', color=color[
+                                                axes_parameters[i][1]])
+                        [lab.set_color(color=color[axes_parameters[i][1]])
+                            for lab in second_ax.yaxis.get_ticklabels()]
+
                         if scale == 'log':
                             second_ax.yaxis.\
                                     set_major_locator(ticker.
@@ -1136,7 +1143,7 @@ class RTP():
             # plot range-time
             else:
                 # Current standard is to only have groundscatter
-                # on the velocity plot. 
+                # on the velocity plot.
                 if groundscatter and axes_parameters[i] == 'v':
                     grndflg = True
                 else:

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -826,7 +826,7 @@ class RTP():
     @classmethod
     def plot_summary(cls, dmap_data: List[dict],
                      beam_num: int = 0, figsize: tuple = (11, 8.5),
-                     watermark: bool = True, boundary: dict = {},
+                     watermark: bool = False, boundary: dict = {},
                      cmaps: dict = {}, lines: dict = {},
                      plot_elv: bool = True, title=None,
                      background: str = 'w', groundscatter: bool = True,


### PR DESCRIPTION
# Scope 

This PR changes the default Nave line in summary plots to be blue. Watermark is now default off. 

**issue:** #324 

## Approval

**Number of approvals:** 2

## Test

**matplotlib version**: 3.7.1
**Note testers: please indicate what version of matplotlib you are using**

Test watermark=True as well.

```python
import matplotlib.pyplot as plt 
import pydarn

file = "/Users/carley/Documents/data/20211102.0000.00.rkn.a.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()
a = pydarn.RTP.plot_summary(fitacf_data , beam_num=13)
plt.show()
```
Gives:
![Screenshot 2023-06-26 at 11 18 41 AM](https://github.com/SuperDARN/pydarn/assets/60905856/ec22bca3-7ff5-469c-80c4-39a3f1880f0d)


