### PR TITLE
BUG: Corrections converting gate to geographic location

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -463,6 +463,13 @@ class Fan():
         if projs == Projs.POLAR:
             beam_corners_lons = np.radians(beam_corners_lons)
 
+        # This section corrects winding order for cartopy plots on a sphere
+        # so that the outline is always anti-clockwise and will fill inside
+        bmsep = SuperDARNRadars.radars[stid].hardware_info.beam_separation
+        if projs == Projs.GEO and bmsep < 0:
+            beam_corners_lons = beam_corners_lons[::-1]
+            beam_corners_lats = beam_corners_lats[::-1]
+
         # Setup plot
         # This may screw up references
         hemisphere = SuperDARNRadars.radars[stid].hemisphere

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -21,7 +21,8 @@
 # 2022-03-23: MTS - added the NotImplementedError for AACGM and GEO projection
 #                   as this has yet to be figured out
 # 2023-02-06: CJM - Added option to plot single beams in a scan or FOV diagram
-#
+# 2023-08-16: CJM - Corrected for winding order in geo plots
+
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
 # Everyone is permitted to copy and distribute verbatim copies of this license

--- a/pydarn/utils/coordinates.py
+++ b/pydarn/utils/coordinates.py
@@ -153,14 +153,16 @@ def gate2geographic_location(stid: int, beam: int, height: float = None,
     # too much converting back and forth.
     boresight = np.radians(SuperDARNRadars.
                            radars[stid].hardware_info.boresight.physical)
+    bmoff = np.radians(SuperDARNRadars.
+                       radars[stid].hardware_info.boresight.electronic)
     radar_lat = np.radians(SuperDARNRadars.
                            radars[stid].hardware_info.geographic.lat)
     radar_lon = np.radians(SuperDARNRadars.
                            radars[stid].hardware_info.geographic.lon)
     # Some beam seperations are negative which changes how the coordinates wrap
     # we absolute to make it easier of fov-color for cartopy plotting
-    beam_sep = np.radians(abs(SuperDARNRadars.
-                          radars[stid].hardware_info.beam_separation))
+    beam_sep = np.radians(SuperDARNRadars.
+                          radars[stid].hardware_info.beam_separation)
     rxrise = SuperDARNRadars.radars[stid].hardware_info.rx_rise_time
 
     # TODO: fix after slant range change
@@ -172,7 +174,7 @@ def gate2geographic_location(stid: int, beam: int, height: float = None,
         beam_edge = 0
 
     # psi [rad] in the angle from the boresight
-    psi = beam_sep * (beam - offset) + beam_edge
+    psi = beam_sep * (beam - offset) - beam_edge + bmoff
     # Calculate the slant range [km]
     if range_estimation != RangeEstimation.RANGE_GATE:
         target_range = range_estimation(rxrise=rxrise, **kwargs)

--- a/pydarn/utils/coordinates.py
+++ b/pydarn/utils/coordinates.py
@@ -13,6 +13,7 @@
 # Modifications:
 # 2022-03-10 MTS added 4 new methods to generate coordinates for the various
 #                enums
+# 2023-08-26 CJM corrected calculations to use bmoff and removed abs()
 #
 
 """
@@ -102,13 +103,13 @@ def convert2MLT(lons: float, date: object, **kwargs):
     return beam_corners_mlts
 
 
-# RPosGeo line 335
 def gate2geographic_location(stid: int, beam: int, height: float = None,
-                             elv_angle: float = 0.0, center: bool = True,
+                             elv_angle: float = 0.0, center: bool = False,
                              range_estimation: RangeEstimation =
                              RangeEstimation.SLANT_RANGE, **kwargs):
     """
     determines the geographic cell position for a given range gate and beam
+    Notes: From RPosGeo line 335
 
     parameters
     ----------
@@ -116,16 +117,6 @@ def gate2geographic_location(stid: int, beam: int, height: float = None,
             station id of the radar to use
         beam: int
             beam number (indexing at 0)
-        range_gate: int
-            range gate number (indexing at 0)
-        rsep: int
-            range seperation, determined by the mode the
-            radar is using, in [km]
-            default: 45 - normalscan mode
-        frang: int
-            frequency range from the radar to the front edge of the range gate
-            Please note: this definition may be changed, currently defined in
-            RST code to keep consistency
         height: float
             transmutation height [km]
             default: none
@@ -135,8 +126,9 @@ def gate2geographic_location(stid: int, beam: int, height: float = None,
             default: 0
         center: bool
             obtain geographic location of the centre of the range gates
-            False obtains the front edge of the range gates.
-            default: True
+            False obtains the near-left corner of the range gates.
+            See also: gate2slant in range_estimation module
+            default: False (return corner values)
 
     returns
     -------
@@ -159,22 +151,21 @@ def gate2geographic_location(stid: int, beam: int, height: float = None,
                            radars[stid].hardware_info.geographic.lat)
     radar_lon = np.radians(SuperDARNRadars.
                            radars[stid].hardware_info.geographic.lon)
-    # Some beam seperations are negative which changes how the coordinates wrap
-    # we absolute to make it easier of fov-color for cartopy plotting
+    # Note that some beam separations are negative
     beam_sep = np.radians(SuperDARNRadars.
                           radars[stid].hardware_info.beam_separation)
     rxrise = SuperDARNRadars.radars[stid].hardware_info.rx_rise_time
 
-    # TODO: fix after slant range change
-    if center is True:
-        # beam edge in [rad]
-        beam_edge = -beam_sep * 0.5
-        # range_edge in [km]
-    else:
+    # If the user wants the edge corner of the range gate:
+    # Radar outwards direction center value is corrected in
+    # range_estimation module
+    if center:
         beam_edge = 0
+    else:
+        beam_edge = -beam_sep * 0.5
 
     # psi [rad] in the angle from the boresight
-    psi = beam_sep * (beam - offset) - beam_edge + bmoff
+    psi = beam_sep * (beam - offset) + beam_edge + bmoff
     # Calculate the slant range [km]
     if range_estimation != RangeEstimation.RANGE_GATE:
         target_range = range_estimation(rxrise=rxrise, **kwargs)

--- a/pydarn/utils/range_estimations.py
+++ b/pydarn/utils/range_estimations.py
@@ -63,7 +63,7 @@ def gate2groundscatter(reflection_height: float = 250, **kwargs):
 
 
 def gate2slant(rxrise: int = 0, range_gate: int = 0, frang: int = 180,
-               rsep: int = 45, nrang: int = None, center: bool = True,
+               rsep: int = 45, nrang: int = None, center: bool = False,
                **kwargs):
     """
     Calculate the slant range (km) for each range gate for SuperDARN data
@@ -87,7 +87,9 @@ def gate2slant(rxrise: int = 0, range_gate: int = 0, frang: int = 180,
             default: None
         center: boolean
             Calculate the slant range in the center of range gate
-            or edge
+            or near-left corner see also: gate2geographic_location in
+            coordinates module
+            default: False (return corner values)
 
     Returns
     -------
@@ -103,13 +105,15 @@ def gate2slant(rxrise: int = 0, range_gate: int = 0, frang: int = 180,
     lag_first = frang * distance_factor / speed_of_light
     # sample separation in microseconds
     sample_sep = rsep * distance_factor / speed_of_light
-    # Range offset
-    # If center is true, calculate at the center
+
+    # Across fov direction is corrected in coordinates module already
+    # 0.5 off set to the centre of the range gate instead of edge
+    # This assumes that frang is to the center of the range gate
     if center:
-        # 0.5 off set to the centre of the range gate instead of edge
-        range_offset = -0.5 * rsep
-    else:
         range_offset = 0.0
+    else:
+        range_offset = -0.5 * rsep
+
     # Now calculate slant range in km
     if nrang is None:
         slant_ranges = (lag_first - rxrise +


### PR DESCRIPTION
# Scope 

This PR changes the calculation for geographic coordinates of the location of each range gate to include the 'offset' value of boresight from hdw files, and removes the abs() function from bmsep calculation to allow for the correct beam numbers. 

As the abs() was originally a bug fix for a colouring-in issue with cartopy plots, this is now taken care of inside the fov method rather than in the position calculation using an if statement. 

**issue:** #351 

## Approval

**Number of approvals:** 2 with a quick code review if possible

## Test

**matplotlib version**: 3.7.1
**Note testers: please indicate what version of matplotlib you are using**

You can plot all the FOV in geographic coordinates, this should colour in the FOv in grey, anything outside should not be shaded:

```python
import pydarn
from datetime import datetime
import matplotlib.pyplot as plt 

# North
stids = [209,208, 211,210,33,207,206,66,205,204,1,10,
         40,41,64,50,3,16,7,90,9,6,65,5,8,32]
plt.figure(figsize=(8, 8))
_,_,ax,ccrs=pydarn.Fan.plot_fov(stids[0], datetime(2021, 2, 5, 0, 5),
                        fov_color= 'grey',radar_location=True,
                        radar_label=True, coastline=True,
                        coords=pydarn.Coords.GEOGRAPHIC,
                        projs=pydarn.Projs.GEO)

for stid in stids[1:]:
    _,_,ax,ccrs=pydarn.Fan.plot_fov(stid, datetime(2021, 2, 5, 0, 5), ax=ax,
                            ccrs=ccrs, fov_color= 'grey',
                            radar_location=True, radar_label=True,
                            coastline=True,
                            coords=pydarn.Coords.GEOGRAPHIC,
                            projs=pydarn.Projs.GEO)
plt.show()

# South
stids = [24,96,97,21,4,15,20,11,22,13,12,14,18,19]
plt.figure(figsize=(8, 8))
_,_,ax,ccrs=pydarn.Fan.plot_fov(stids[0], datetime(2021, 2, 5, 0, 5),
                        fov_color= 'grey',radar_location=True,
                        radar_label=True, coastline=True,
                        coords=pydarn.Coords.GEOGRAPHIC,
                        projs=pydarn.Projs.GEO)

for stid in stids[1:]:
    _,_,ax,ccrs=pydarn.Fan.plot_fov(stid, datetime(2021, 2, 5, 0, 5), ax=ax,
                            ccrs=ccrs, fov_color= 'grey',
                            radar_location=True, radar_label=True,
                            coords=pydarn.Coords.GEOGRAPHIC,
                            projs=pydarn.Projs.GEO)
plt.show()
```
<img width="763" alt="Screenshot 2023-08-16 at 4 07 20 PM" src="https://github.com/SuperDARN/pydarn/assets/60905856/9e8561b7-92dc-4147-a189-7ca120fdc39a">

<img width="740" alt="Screenshot 2023-08-16 at 4 07 05 PM" src="https://github.com/SuperDARN/pydarn/assets/60905856/fe64d7a8-8f7a-4321-a66f-dc7c51c16629">


To check on the direction of beams, you can use the following code:

```python
import pydarn
from datetime import datetime
import matplotlib.pyplot as plt 

plt.figure(figsize=(8, 8))
stids = [20]
_,_,ax,ccrs=pydarn.Fan.plot_fov(stids[0], datetime(2021, 2, 5, 0, 5),
                        fov_color= 'grey',radar_location=True,
                        radar_label=True, coastline=True,
                        coords=pydarn.Coords.GEOGRAPHIC,
                        projs=pydarn.Projs.GEO)
_,_,ax,ccrs=pydarn.Fan.plot_fov(stids[0], datetime(2021, 2, 5, 0, 5), ax=ax,
                        fov_color= 'red', beam=0, ccrs=ccrs,
                        coords=pydarn.Coords.GEOGRAPHIC,
                        projs=pydarn.Projs.GEO)
_,_,ax,ccrs=pydarn.Fan.plot_fov(stids[0], datetime(2021, 2, 5, 0, 5), ax=ax,
                        fov_color= 'blue', beam=15, ccrs=ccrs,
                        coords=pydarn.Coords.GEOGRAPHIC,
                        projs=pydarn.Projs.GEO)
plt.show()


plt.figure(figsize=(8, 8))
stids = [24]
_,_,ax,ccrs=pydarn.Fan.plot_fov(stids[0], datetime(2021, 2, 5, 0, 5),
                        fov_color= 'grey',radar_location=True,
                        radar_label=True, coastline=True,
                        coords=pydarn.Coords.GEOGRAPHIC,
                        projs=pydarn.Projs.GEO)
_,_,ax,ccrs=pydarn.Fan.plot_fov(stids[0], datetime(2021, 2, 5, 0, 5), ax=ax,
                        fov_color= 'red', beam=0, ccrs=ccrs,
                        coords=pydarn.Coords.GEOGRAPHIC,
                        projs=pydarn.Projs.GEO)
_,_,ax,ccrs=pydarn.Fan.plot_fov(stids[0], datetime(2021, 2, 5, 0, 5), ax=ax,
                        fov_color= 'blue', beam=15, ccrs=ccrs,
                        coords=pydarn.Coords.GEOGRAPHIC,
                        projs=pydarn.Projs.GEO)
plt.show()
```

This code checks the first and 15th beam (red and blue) for a -ve and +ve bmsep value:
<img width="731" alt="Screenshot 2023-08-16 at 4 16 34 PM" src="https://github.com/SuperDARN/pydarn/assets/60905856/1786cdd0-7773-4e9d-8b94-ff083bed565d">
<img width="745" alt="Screenshot 2023-08-16 at 4 16 45 PM" src="https://github.com/SuperDARN/pydarn/assets/60905856/0cebd794-71d7-458e-a58f-db4872b9b973">


These all require Cartopy to be installed - you can remove the projs, coords and coastline keywords to test in magnetic coordinates without cartopy.

Please check out the associated issue for further discussion!

