### PR TITLE
EHN: Replace GSMR equation

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -1182,6 +1182,8 @@ class RTP():
                     axes[i].set_ylabel('Slant Range (km)')
                 elif range_estimation == RangeEstimation.GSMR:
                     axes[i].set_ylabel('Ground Scatter\nMapped Range\n(km)')
+                elif range_estimation == RangeEstimation.GSMR_BRISTOW:
+                    axes[i].set_ylabel('Ground Scatter\nMapped Range\n(km)')
                 elif range_estimation == RangeEstimation.HALF_SLANT:
                     axes[i].set_ylabel('Slant Range/2\n(km)')
                 else:

--- a/pydarn/utils/range_estimations.py
+++ b/pydarn/utils/range_estimations.py
@@ -38,7 +38,7 @@ def gate2halfslant(**kwargs):
     return half_slant
 
 
-def gate2groundscatter(reflection_height: float = 250, **kwargs):
+def gate2gs_bristow(reflection_height: float = 250, **kwargs):
     """
     Calculate the ground scatter mapped range (km) for each slanted range
     for SuperDARN data. This function is based on the Ground Scatter equation
@@ -58,6 +58,36 @@ def gate2groundscatter(reflection_height: float = 250, **kwargs):
     ground_scatter_mapped_ranges =\
             Re*np.arcsin(np.sqrt((slant_ranges**2/4)-
                                  (reflection_height**2))/Re)
+
+    return ground_scatter_mapped_ranges
+
+
+def gate2groundscatter(reflection_height: float = 250, hop: float = 0.5,
+                       **kwargs):
+    """
+    Calculate the ground scatter mapped range (km) for each slanted range
+    for SuperDARN data. This function is based on the Ground Scatter equation
+    discussed in the issue github.com/SuperDARN/pydarn/issues/257
+    Parameters
+    ----------
+        reflection_height: float
+            reflection height
+            default:  250
+        hop: float
+            hop numberof returning data
+            default: 0.5
+
+    Returns
+    -------
+        ground_scatter_mapped_ranges : np.array
+            returns an array of ground scatter mapped ranges for the radar
+    """
+    slant_ranges = gate2slant(**kwargs)
+
+    num = - Re**2 - (Re + reflection_height)**2\
+          + (slant_ranges * (0.5 / hop))**2
+    den = 2 * Re * (Re + reflection_height)
+    ground_scatter_mapped_ranges = (hop/0.5) * Re * np.arccos( - num / den )
 
     return ground_scatter_mapped_ranges
 
@@ -139,6 +169,7 @@ class RangeEstimation(enum.Enum):
     SLANT_RANGE = (gate2slant,)
     HALF_SLANT = (gate2halfslant,)
     GSMR = (gate2groundscatter,)
+    GSMR_BRISTOW = (gate2gs_bristow,)
 
     # Need this to make the functions callable
     def __call__(self, *args, **kwargs):

--- a/pydarn/utils/range_estimations.py
+++ b/pydarn/utils/range_estimations.py
@@ -16,8 +16,11 @@
 
 import enum
 import numpy as np
+import warnings
 
-from pydarn import Re, C
+from pydarn import Re, C, standard_warning_format
+
+warnings.formatwarning = standard_warning_format
 
 
 def gate2halfslant(**kwargs):
@@ -38,15 +41,15 @@ def gate2halfslant(**kwargs):
     return half_slant
 
 
-def gate2gs_bristow(reflection_height: float = 250, **kwargs):
+def gate2gs_bristow(virtual_height: float = 250, **kwargs):
     """
     Calculate the ground scatter mapped range (km) for each slanted range
     for SuperDARN data. This function is based on the Ground Scatter equation
     from Bristow paper at https://doi.org/10.1029/93JA01470 on page 325
     Parameters
     ----------
-        reflection_height: float
-            reflection height
+        virtual_height: float
+            virtual height
             default:  250
 
     Returns
@@ -55,14 +58,22 @@ def gate2gs_bristow(reflection_height: float = 250, **kwargs):
             returns an array of ground scatter mapped ranges for the radar
     """
     slant_ranges = gate2slant(**kwargs)
-    ground_scatter_mapped_ranges =\
-            Re*np.arcsin(np.sqrt((slant_ranges**2/4)-
-                                 (reflection_height**2))/Re)
-
+    ground_scatter_mapped_ranges = Re * np.arcsin(np.sqrt((slant_ranges**2 / 4)
+                                                  - (virtual_height**2)) / Re)
+    # Check to see if there is an issue with the sqrt and
+    # give user a warning if so, these values will be dealt with in
+    # the individual plotting algs as we need to return the full array
+    # of values for the complete beam*range gate array
+    if any(np.isfinite(ground_scatter_mapped_ranges)):
+        warnings.warn("Warning: Be aware that the range estimation"
+                      " you have chosen has calculated some infinite"
+                      " values. These values will not be plotted."
+                      " You may use RangeEstimation.GSMR to avoid this"
+                      " issue.")
     return ground_scatter_mapped_ranges
 
 
-def gate2groundscatter(reflection_height: float = 250, hop: float = 0.5,
+def gate2groundscatter(virtual_height: float = 250, hop: float = 0.5,
                        **kwargs):
     """
     Calculate the ground scatter mapped range (km) for each slanted range
@@ -70,11 +81,11 @@ def gate2groundscatter(reflection_height: float = 250, hop: float = 0.5,
     discussed in the issue github.com/SuperDARN/pydarn/issues/257
     Parameters
     ----------
-        reflection_height: float
-            reflection height
+        virtual_height: float
+            virtual height
             default:  250
         hop: float
-            hop numberof returning data
+            hop number of returning data
             default: 0.5
 
     Returns
@@ -84,10 +95,10 @@ def gate2groundscatter(reflection_height: float = 250, hop: float = 0.5,
     """
     slant_ranges = gate2slant(**kwargs)
 
-    num = - Re**2 - (Re + reflection_height)**2\
-          + (slant_ranges * (0.5 / hop))**2
-    den = 2 * Re * (Re + reflection_height)
-    ground_scatter_mapped_ranges = (hop/0.5) * Re * np.arccos( - num / den )
+    num = - Re**2 - (Re + virtual_height)**2\
+        + (slant_ranges/2 * (0.5 / hop))**2
+    den = 2 * Re * (Re + virtual_height)
+    ground_scatter_mapped_ranges = (hop/0.5) * Re * np.arccos(- num / den)
 
     return ground_scatter_mapped_ranges
 

--- a/pydarn/utils/range_estimations.py
+++ b/pydarn/utils/range_estimations.py
@@ -12,7 +12,7 @@
 #
 # Modifications:
 # 2022-08-04 CJM added HALF_SLANT option and gate2halfslant method
-#
+# 2023-09-14 CJM moved GSMR to GSMR_BRISTOW and used new GSMR alg
 
 import enum
 import numpy as np


### PR DESCRIPTION
# Scope 

This pull request replaces the current equation to calculate the GSMR range estimate, and makes a new method for GSMR_BRISTOW which uses the older Bristow GSMR version.
There is also a new warning when inf values are found during the Bristow equation method. 

You can read the discussion of this issue at #257

**issue:** to close #257 

## Approval

**Number of approvals:** 2

## Test

**matplotlib version**: 3.7.2
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt 
import pydarn

file = "/Users/carley/Documents/data/20211102.0000.00.rkn.a.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

a = pydarn.RTP.plot_summary(fitacf_data, beam_num=2, range_estimation=pydarn.RangeEstimation.GSMR, watermark=False, title='New GSMR Eqn')
plt.show()
a = pydarn.RTP.plot_summary(fitacf_data, beam_num=2, range_estimation=pydarn.RangeEstimation.GSMR_BRISTOW, watermark=False, title='Old GSMR (GSMR_BRISTOW)')
plt.show()
a = pydarn.RTP.plot_summary(fitacf_data, beam_num=2, range_estimation=pydarn.RangeEstimation.SLANT_RANGE, watermark=False, title='Slant Range')
plt.show()
```
Will give:
![Screenshot 2023-09-14 at 12 01 04 PM](https://github.com/SuperDARN/pydarn/assets/60905856/1cc43254-efe0-47f5-9d94-e355f68801df)
![Screenshot 2023-09-14 at 12 01 19 PM](https://github.com/SuperDARN/pydarn/assets/60905856/7d75f5df-e58b-4ead-9096-df04c6b5e619)
![Screenshot 2023-09-14 at 12 01 31 PM](https://github.com/SuperDARN/pydarn/assets/60905856/7bfe6229-1611-44ac-bff6-de0cc1c5a8b5)

For now the warning message will not show up, warnings for summary plots are fixed in another PR.