### PR TITLE
New time of flight range estimation

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -450,11 +450,14 @@ class RTP():
 
         ax.set_ylim(ymin, ymax)
 
-        if range_estimation != RangeEstimation.RANGE_GATE:
+        if (range_estimation != RangeEstimation.RANGE_GATE and
+            range_estimation != RangeEstimation.TIME_OF_FLIGHT):
             ax.yaxis.set_ticks(np.arange(np.ceil(ymin/100.0)*100,
                                          ymax+1, yspacing))
-        else:
+        elif range_estimation == RangeEstimation.RANGE_GATE:
             ax.yaxis.set_ticks(np.arange(ymin, ymax+1, (ymax)/5))
+        else:
+            ax.yaxis.set_ticks(np.arange(0, np.ceil(ymax)+1, 5))
 
         # SuperDARN file typically are in 2hr or 24 hr files
         # to make the minute ticks sensible, the time length is detected
@@ -1235,8 +1238,10 @@ class RTP():
                     axes[i].set_ylabel('Ground Scatter\nMapped Range\n(km)')
                 elif range_estimation == RangeEstimation.HALF_SLANT:
                     axes[i].set_ylabel('Slant Range/2\n(km)')
-                else:
+                elif range_estimation == RangeEstimation.RANGE_GATE:
                     axes[i].set_ylabel('Range Gates')
+                else:
+                    axes[i].set_ylabel('Time of Flight\n(ms)')
             if i < num_plots-1:
                 axes[i].set_xticklabels([])
             # last plot needs the label on the x-axis

--- a/pydarn/utils/coordinates.py
+++ b/pydarn/utils/coordinates.py
@@ -167,13 +167,18 @@ def gate2geographic_location(stid: int, beam: int, height: float = None,
     # psi [rad] in the angle from the boresight
     psi = beam_sep * (beam - offset) + beam_edge + bmoff
     # Calculate the slant range [km]
-    if range_estimation != RangeEstimation.RANGE_GATE:
-        target_range = range_estimation(rxrise=rxrise, **kwargs)
+    if range_estimation == RangeEstimation.RANGE_GATE:
+        raise radar_exceptions.RangeEstimationError("Range gates cannot be "
+                                                    "used in to estimate "
+                                                    "distance. Try SLANT_RANGE"
+                                                    " instead.")
+    elif range_estimation == RangeEstimation.TIME_OF_FLIGHT:
+        raise radar_exceptions.RangeEstimationError("Time of flight cannot be "
+                                                    "used in to estimate "
+                                                    "distance. Try SLANT_RANGE"
+                                                    " instead.")
     else:
-        raise radar_exceptions.RangeEstimationError("Range Gates cannot be"
-                                                    "used in estimating the"
-                                                    " km for geographic"
-                                                    " coordinates systems")
+        target_range = range_estimation(rxrise=rxrise, **kwargs)
 
     # If no height is specified then use elevation angle (default 0)
     # to calculate the transmutation height


### PR DESCRIPTION
# Scope 

New range estimation variant, using time of flight.

**issue:** #348 

## Approval

**Number of approvals:** *1*

## Test

**matplotlib version**: 3.7.2

Try this modified snippet from the summary plotting tutorial https://pydarn.readthedocs.io/en/main/user/summary/

```python3
import matplotlib.pyplot as plt

import pydarn

fitacf_file = "20190831.C0.cly.fitacf"
darn_read = pydarn.SuperDARNRead(fitacf_file)
fitacf_data = darn_read.read_fitacf()

pydarn.RTP.plot_summary(fitacf_data, beam_num=2,
                        range_estimation=pydarn.RangeEstimation.TIME_OF_FLIGHT)
plt.show()
```
