### PR TITLE
Option to output coastline coordinates in magnetlic longitude

### DIFF
--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -45,7 +45,7 @@ except Exception:
     cartopyInstalled = False
 
 
-def convert_coastline_list_to_mag(geom, date, alt: float = 0.0):
+def convert_coastline_list_to_mag(geom, date, alt: float = 0.0, mag_lon=None):
     '''
     Takes a list of coastlines and converts
     the coordinates into AACGM_MLT
@@ -58,6 +58,8 @@ def convert_coastline_list_to_mag(geom, date, alt: float = 0.0):
     alt: float
         Altitude in km
         Default 0 (sea level) for coastlines
+    mag_lon: bool
+        Set true to return magnetic longitude, not MLT
     '''
     [mlat, lon_mag, _] = \
         aacgmv2.convert_latlon_arr(geom['lat'], geom['lon'], alt, date,
@@ -65,11 +67,16 @@ def convert_coastline_list_to_mag(geom, date, alt: float = 0.0):
     # Clean Nans (effects plotting)
     mlat = mlat[np.logical_not(np.isnan(mlat))]
     lon_mag = lon_mag[np.logical_not(np.isnan(lon_mag))]
-    # Shift to MLT
-    shifted_mlts = lon_mag[0] - (aacgmv2.convert_mlt(lon_mag[0], date) * 15)
-    shifted_lons = lon_mag - shifted_mlts
-    mlon = np.radians(shifted_lons)
-    return [mlat, mlon]
+
+    if mag_lon is True:
+        mlon = np.radians(lon_mag)
+        return [mlat, mlon]
+    else:
+        # Shift to MLT
+        shifted_mlts = lon_mag[0] - (aacgmv2.convert_mlt(lon_mag[0], date) * 15)
+        shifted_lons = lon_mag - shifted_mlts
+        mlon = np.radians(shifted_lons)
+        return [mlat, mlon]
 
 
 def convert_geo_coastline_to_mag(geom, date, alt: float = 0.0, mag_lon=None):

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -72,7 +72,7 @@ def convert_coastline_list_to_mag(geom, date, alt: float = 0.0):
     return [mlat, mlon]
 
 
-def convert_geo_coastline_to_mag(geom, date, alt: float = 0.0):
+def convert_geo_coastline_to_mag(geom, date, alt: float = 0.0, mag_lon=None):
     """
     Takes the geometry object of coastlines and converts
     the coordinates into AACGM_MLT
@@ -87,6 +87,8 @@ def convert_geo_coastline_to_mag(geom, date, alt: float = 0.0):
     alt: float
         Altitude in km
         Default 0 (sea level) for coastlines
+    mag_lon: bool
+        Set true to return magnetic longitude, not MLT
     """
     # Iterate over the coordinates and convert to MLT
     def convert_to_mag(date, alt):
@@ -94,10 +96,15 @@ def convert_geo_coastline_to_mag(geom, date, alt: float = 0.0):
             [mlat, lon_mag, _] = \
                 aacgmv2.convert_latlon_arr(glat, glon, alt,
                                            date, method_code='G2A')
-            # Shift to MLT
-            shifted_mlts = lon_mag[0] - \
-                (aacgmv2.convert_mlt(lon_mag[0], date) * 15)
-            shifted_lons = lon_mag - shifted_mlts
+
+            if mag_lon is True:
+                shifted_lons = lon_mag
+            else:
+                # Shift to MLT
+                shifted_mlts = lon_mag[0] - \
+                    (aacgmv2.convert_mlt(lon_mag[0], date) * 15)
+                shifted_lons = lon_mag - shifted_mlts
+
             mlon = np.radians(shifted_lons)
             yield mlon.item(), mlat.item()
 


### PR DESCRIPTION
# Scope 

This PR adds an option for outputting coastlines in geomagnetic longitude. Previously, `convert_geo_coastline_to_mag` (Cartopy version) and `convert_coastline_list_to_mag` (non-Cartopy) could only produce mlat-MLT coordinates. Now there is an option to not do the MLT rotation and produce mlat-mlon coordinates. It is off by default to not disrupt default plotting.

As there is currently no polar projections which use magnetic longitude, this currently has no default use in pyDARN. When/if projections using mlon are set up, these can be used to get coastlines correctly.

## Test


```python
# Use case with cartopy installed
import cartopy.feature as cfeature
import datetime as dt
from pydarn.plotting.projections import convert_geo_coastline_to_mag

# Set a time, required for the magnetic conversion
time = dt.datetime(2024, 1, 18)

# Read in the geometry object of the coastlines
cc = cfeature.NaturalEarthFeature('physical', 'coastline', '50m',
                                      color='k', zorder=2.0)

# Iterate over the geometry objects (with coordinates in geographic) and send them to get converted
for geom in cc.geometries():
    coastline_mlt = convert_geo_coastline_to_mag(geom, time)
    coastline_mlon = convert_geo_coastline_to_mag(geom, time, mag_lon=True)
    mlt, mlat = coastline_mlt.coords.xy[0], coastline_mlt.coords.xy[1]
    mlon, mlat = coastline_mlon.coords.xy[0], coastline_mlon.coords.xy[1]
```

```python
# Use case without cartopy installed
from pydarn import coast_outline
from pydarn.plotting.projections import convert_coastline_list_to_mag
import datetime as dt

# Set a time, required for the magnetic conversion
time = dt.datetime(2024, 1, 18)

# Iterate over the geometry objects for the saved coastlines
for geom in coast_outline:
    [mlat, mlt] = convert_coastline_list_to_mag(geom, time)
    [mlat, mlon] = convert_coastline_list_to_mag(geom, time, mag_lon=True)
```


