### PR TITLE
Calculating potentials at any coordinate

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -1006,7 +1006,7 @@ class Maps():
         return mlat_center, mlon_center, pot_arr
 
 
-      @classmethod
+    @classmethod
     def calculate_potentials_pos(cls, mlat, mlon, fit_coefficient: list, lat_min,
                                  lat_shift: int = 0, lon_shift: int = 0,
                                  fit_order: int = 6, hemisphere: Enum = Hemisphere.North,

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -1005,11 +1005,11 @@ class Maps():
 
         return mlat_center, mlon_center, pot_arr
 
-
     @classmethod
-    def calculate_potentials_pos(cls, mlat, mlon, fit_coefficient: list, lat_min,
-                                 lat_shift: int = 0, lon_shift: int = 0,
-                                 fit_order: int = 6, hemisphere: Enum = Hemisphere.North,
+    def calculate_potentials_pos(cls, mlat, mlon, fit_coefficient: list,
+                                 lat_min: list, lat_shift: int = 0,
+                                 lon_shift: int = 0, fit_order: int = 6,
+                                 hemisphere: Enum = Hemisphere.North,
                                  **kwargs):
         '''
         Calculates potential for a specific magnetic latitude and longitude,
@@ -1039,7 +1039,18 @@ class Maps():
                 Describes the hemisphere, North or South
                 default: Hemisphere.North
 
+        Returns
+        -------
+        v: List[float]
+            list of potentials at given position(s) in kV
         '''
+        # Check input is in correct format and lengths
+        if not isinstance(mlat, list):
+            mlat = [mlat]
+        if not isinstance(mlon, list):
+            mlon = [mlon]
+        if not len(mlat) == len(mlon):
+            raise ValueError('mlat and mlon must be the same length.')
 
         # Lowest latitude to calculate potential to
         theta_max = np.radians(90 - np.abs(lat_min) + 10) * hemisphere.value
@@ -1082,7 +1093,6 @@ class Maps():
         v /= 1000
 
         return v
-
 
     @classmethod
     def plot_potential_contours(cls, fit_coefficient: list, lat_min: list,

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -1041,8 +1041,8 @@ class Maps():
 
         Returns
         -------
-        v: List[float]
-            list of potentials at given position(s) in kV
+            v: List[float]
+                list of potentials at given position(s) in kV
         '''
         # Check input is in correct format and lengths
         if not isinstance(mlat, list):


### PR DESCRIPTION
This PR implements a new method `calulate_potentials_pos()` for calculating the electric potentials at any given magnetic latitude and magnetic longitude. The code is mostly ripped from `calculate_potentials()`, but adjusted slightly / cleaned up so that there is no pre-defined grid (for plotting), and so that mlat/mlon can be given as inputs. 

## Approval

2

## Test

```python
import pydarn


mapfile = '20230123.n.map'

SDarn_read = pydarn.SuperDARNRead(mapfile)
map_data = SDarn_read.read_map()

# Coordinates of interest, as mlat/mlon pairs. 
#This example keeps mlon the same but changes mlat, like a keogram
mlats = [75, 76, 77, 78] 
mlons = [110, 110, 110, 110]

# Map parameters from the mapfile, first record
fit_coefficient = map_data[0]['N+2']
fit_order = map_data[0]['fit.order']
lat_shift = map_data[0]['lat.shft']
lon_shift = map_data[0]['lon.shft']
lat_min = map_data[0]['latmin']
hemisphere = pydarn.Hemisphere(map_data[0]['hemisphere'])

# Get the potentials for my coordinates
pots = pydarn.Maps.calculate_potentials_pos(mlats, mlons, fit_coefficient, lat_min, lat_shift, lon_shift,
                                            fit_order, hemisphere)

```
