### PR TITLE
Fix colourbar alpha for filled potential contours

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -1226,19 +1226,18 @@ class Maps():
             # Filled contours
             norm = colors.Normalize
             norm = norm(pot_zmin, pot_zmax)
-            cs = plt.contourf(np.radians(mlon), mlat, pot_arr, 2,
-                              norm=norm, vmax=pot_zmax, vmin=pot_zmin,
+            cs = plt.contourf(np.radians(mlon), mlat, pot_arr, 2, norm=norm,
+                              vmax=pot_zmax,
+                              vmin=pot_zmin,
                               levels=np.array(contour_levels),
                               cmap=contour_fill_cmap, alpha=0.5,
                               extend='both', zorder=3.0)
             if contour_colorbar is True:
-                mappable = cm.ScalarMappable(norm=norm, cmap=contour_fill_cmap)
                 locator = ticker.MaxNLocator(symmetric=True, min_n_ticks=3,
                                              integer=True, nbins='auto')
                 ticks = locator.tick_values(vmin=pot_zmin,
                                             vmax=pot_zmax)
-                cb_contour = plt.colorbar(mappable, ax=ax, extend='both',
-                                          ticks=ticks)
+                cb_contour = plt.colorbar(cs, ax=ax, extend='both', ticks=ticks)
                 if contour_colorbar_label != '':
                     cb_contour.set_label(contour_colorbar_label)
             else:


### PR DESCRIPTION
# Scope 

This fixes the colourbar shown when plotting filled contours for a convection map. Previously, the alpha value of the contours were not carried over to the colourbar because a whole new `mappable` object was being made for the colourmap of choice. This PR simply uses the output from `plt.contourf()` when making the colourbar so that the alpha is retained.

Current behaviour:
<img width="843" alt="Screenshot 2024-01-31 at 2 58 15 PM" src="https://github.com/SuperDARN/pydarn/assets/26160732/1f37187a-25cb-447b-820a-d645c936b0f6">

Fixed behaviour:
<img width="841" alt="Screenshot 2024-01-31 at 2 57 50 PM" src="https://github.com/SuperDARN/pydarn/assets/26160732/eee2ef45-cfa0-4a3e-ab0d-1fe8bcc8c456">


## Approval

2

## Test


