### PR TITLE
Add alpha to plt.colorbar when using pyplot.contourf

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -1238,7 +1238,7 @@ class Maps():
                 ticks = locator.tick_values(vmin=pot_zmin,
                                             vmax=pot_zmax)
                 cb_contour = plt.colorbar(mappable, ax=ax, extend='both',
-                                          ticks=ticks)
+                                          ticks=ticks, alpha=0.5)
                 if contour_colorbar_label != '':
                     cb_contour.set_label(contour_colorbar_label)
             else:


### PR DESCRIPTION
# Scope 

This is a really small change to fix the alpha in the map potential colour bar. The `mappable` object created for the colour bar doesn't preserve the alpha used when using `plt.contourf()`. This change adds it in.

Current behaviour:
<img width="843" alt="Screenshot 2024-01-31 at 2 58 15 PM" src="https://github.com/SuperDARN/pydarn/assets/26160732/356be379-e6f6-4af8-b4d9-be3fb67d8d57">

Fixed behaviour:
<img width="835" alt="Screenshot 2024-01-31 at 3 29 54 PM" src="https://github.com/SuperDARN/pydarn/assets/26160732/0c0c669b-4e0b-4ab8-9d6c-f1a95e040a88">

**issue:**

## Approval

1

## Test

```python
import pydarn
import matplotlib.pyplot as plt
import datetime as dt

mapfile = '20221130.n.map'
SDarn_read = pydarn.SuperDARNRead(mapfile)
map_data = SDarn_read.read_map()
record = dt.datetime(2022, 11, 30, 15, 0)
pydarn.Maps.plot_mapdata(map_data, start_time=record, lowlat=50, coastline=True, contour_fill=True, color_vectors=False)
```


