### PR TITLE
Fix colourbar preference not being preserved

### DIFF
--- a/docs/user/map.md
+++ b/docs/user/map.md
@@ -86,6 +86,7 @@ Here is a list of all the current options than can be used with `plot_mapdata`
 | color_vectors=(bool)           | Choose if the vectors are plotted with corresponding color map (True), or in black    |
 | colorbar=(bool)                | Set true to plot a colorbar (default: True)                                           |
 | colorbar_label=(string)        | Label for the colour bar (requires colorbar to be true)                               |
+| contour_colorbar=(bool)        | Set True to show color bar for contour color map (default:True if contour_fill=True)  |
 | title=(str)                    | To add a title to the plot                                                            |
 | hmb=(bool)                     | Set to True to include the Heppnar-Maynard Boundary on the plot                       |
 | imf_dial=(bool)                | Show the IMF data as a clock angle dial (default True)                                |

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -133,7 +133,7 @@ class Maps():
                 Default: True
             contour_colorbar: bool
                 Draw a contour colourbar if True
-                Default: False
+                Default: True
             colorbar_label: str
                 The label that appears next to the colour bar.
                 Requires colorbar to be true

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -70,7 +70,8 @@ class Maps():
                      record: int = 0, start_time: dt.datetime = None,
                      time_delta: float = 1,  alpha: float = 1.0,
                      len_factor: float = 150, color_vectors: bool = True,
-                     cmap: str = None, colorbar: bool = True, contour_colorbar=False,
+                     cmap: str = None, colorbar: bool = True, 
+                     contour_colorbar: bool = True,
                      colorbar_label: str = '', title: str = '',
                      zmin: float = None, zmax: float = None,
                      hmb: bool = True, boundary: bool = False,
@@ -503,7 +504,7 @@ class Maps():
                                         lat_shift=lat_shift,
                                         lon_shift=lon_shift,
                                         fit_order=fit_order,
-                                        hemisphere=hemisphere
+                                        hemisphere=hemisphere,
                                         contour_colorbar=contour_colorbar,
                                         **kwargs)
 

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -70,7 +70,7 @@ class Maps():
                      record: int = 0, start_time: dt.datetime = None,
                      time_delta: float = 1,  alpha: float = 1.0,
                      len_factor: float = 150, color_vectors: bool = True,
-                     cmap: str = None, colorbar: bool = True,
+                     cmap: str = None, colorbar: bool = True, contour_colorbar=False,
                      colorbar_label: str = '', title: str = '',
                      zmin: float = None, zmax: float = None,
                      hmb: bool = True, boundary: bool = False,
@@ -130,6 +130,9 @@ class Maps():
             colorbar: bool
                 Draw a colourbar if True
                 Default: True
+            contour_colorbar: bool
+                Draw a contour colourbar if True
+                Default: False
             colorbar_label: str
                 The label that appears next to the colour bar.
                 Requires colorbar to be true
@@ -501,7 +504,7 @@ class Maps():
                                         lon_shift=lon_shift,
                                         fit_order=fit_order,
                                         hemisphere=hemisphere
-                                        contour_colorbar=colorbar,
+                                        contour_colorbar=contour_colorbar,
                                         **kwargs)
 
         if hmb is True:

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -500,7 +500,8 @@ class Maps():
                                         lat_shift=lat_shift,
                                         lon_shift=lon_shift,
                                         fit_order=fit_order,
-                                        hemisphere=hemisphere,
+                                        hemisphere=hemisphere
+                                        contour_colorbar=colorbar,
                                         **kwargs)
 
         if hmb is True:


### PR DESCRIPTION
# Scope 

This is a very small PR which fixes the behaviour of colourbars when making a convection map. Previously, setting `colorbar=False` when using `plot_mapdata()` would not work if `contour_fill=True`. This is because `plot_potential_contours()` uses a different keyword to control the colourbar for contours, and the one used in `plot_mapdata()` only controls the velocity colourbar.

This PR adds a second keyword to control the potential contour colourbar, `contour_colorbar`, which is set to False as default.

## Approval

1

## Test

```python
import pydarn
import matplotlib.pyplot as plt

mapfile = '20231004.n.map'
SDarn_read = pydarn.SuperDARNRead(mapfile)
map_data = SDarn_read.read_map()

pydarn.Maps.plot_mapdata(map_data, record=0, lowlat=50, coastline=True, contour_fill=True, color_vectors=False, colorbar=False, contour_colorbar=False)
```

Gives:
<img width="616" alt="Screenshot 2024-02-13 at 9 57 47 AM" src="https://github.com/SuperDARN/pydarn/assets/26160732/67e88317-834f-46d7-b489-f614f1e315ce">



