### PR TITLE
Fixed `map_info=False` not working

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -142,6 +142,9 @@ class Maps():
                 Normalisation factor for the vectors, to control size on plot
                 Larger number means smaller vectors on plot
                 Default: 150.0
+            map_info: bool
+                If true, write information about the map on the plot 
+                (fit order, CPCP, number of points)
             imf_dial: bool
                 If True, draw an IMF dial of the magnetic field clock angle.
                 Default: True
@@ -528,10 +531,10 @@ class Maps():
                               zfill(2))
         plt.title(title)
 
+        model = dmap_data[record]['model.name']
+        num_points = len(dmap_data[record]['vector.mlat'])
+        pol_cap_pot = dmap_data[record]['pot.drop']
         if map_info is True:
-            model = dmap_data[record]['model.name']
-            num_points = len(dmap_data[record]['vector.mlat'])
-            pol_cap_pot = dmap_data[record]['pot.drop']
             cls.add_map_info(fit_order, pol_cap_pot, num_points, model)
 
         bx = dmap_data[record]['IMF.Bx']


### PR DESCRIPTION
# Scope 

Setting `map_info=False` when using `plot_mapdata()` didn't work previously because it would cause parameters (like the number of points and the cross-polar-cap potential) to not be stored into variables, causing the code to break at the return statement. This PR fixes the keyword when set to False by only checking it after those values are stored in variables. I also added `map_info` to the docstring, because it wasn't there before.

## Approval

1

## Test

```python
import pydarn
import matplotlib.pyplot as plt

mapfile = '20231004.n.map'
SDarn_read = pydarn.SuperDARNRead(mapfile)
map_data = SDarn_read.read_map()

pydarn.Maps.plot_mapdata(map_data, record=0, lowlat=50, map_info=False)
plt.show()
```

Gives:
<img width="627" alt="Screenshot 2024-02-13 at 10 09 49 AM" src="https://github.com/SuperDARN/pydarn/assets/26160732/9203f13b-7a16-4de7-b450-75f9d69e1513">


