### PR TITLE
Change input types, remove len_factor from calculated_fitted_velocities()

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -585,8 +585,8 @@ class Maps():
                                      and (m != 0) and l**2 + 2 * m - 1) or 0
 
     @classmethod
-    def calculated_fitted_velocities(cls, mlats: list, mlons: list,
-                                     fit_coefficient: list,
+    def calculated_fitted_velocities(cls, mlats: np.array, mlons: np.array,
+                                     fit_coefficient: np.array,
                                      hemisphere: Enum = Hemisphere.North,
                                      fit_order: int = 6, lat_min: int = 60):
         """

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -143,7 +143,7 @@ class Maps():
                 Larger number means smaller vectors on plot
                 Default: 150.0
             map_info: bool
-                If true, write information about the map on the plot 
+                If true, write information about the map on the plot
                 (fit order, CPCP, number of points)
             imf_dial: bool
                 If True, draw an IMF dial of the magnetic field clock angle.
@@ -245,8 +245,7 @@ class Maps():
                                                      fit_order=dmap_data[
                                                          record]['fit.order'],
                                                      lat_min=dmap_data[
-                                                         record]['latmin'],
-                                                     len_factor=len_factor)
+                                                         record]['latmin'])
 
         elif parameter == MapParams.MODEL_VELOCITY:
             v_mag = dmap_data[record]['model.vel.median']

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -588,19 +588,18 @@ class Maps():
     def calculated_fitted_velocities(cls, mlats: list, mlons: list,
                                      fit_coefficient: list,
                                      hemisphere: Enum = Hemisphere.North,
-                                     fit_order: int = 6, lat_min: int = 60,
-                                     len_factor: int = 150):
+                                     fit_order: int = 6, lat_min: int = 60):
         """
         Calculates the fitted velocities using Legrendre polynomial
 
         Parameters
         ----------
-            mlats: List[float]
+            mlats: Array[float]
                 Magnetic Latitude in degrees
-            mlons: List[float]
+            mlons: Array[float]
                 Magnetic Longitude in radians
-            fit_coefficient: List[float]
-                Value of the coefficient
+            fit_coefficient: Array[float]
+                Value of the mapfile coefficients (from record key ['N+2'])
             hemisphere: int
                 1 or -1 for hemisphere North or South
                 default: 1 - North
@@ -610,9 +609,6 @@ class Maps():
             lat_min: int
                 Lower latitude boundary of data in degrees
                 default: 60
-            len_factor: int
-                length of the vector socks multiplied by
-                default: 150
         """
         # convert earth radius to meters
         Re_meters = Re * 1000.0


### PR DESCRIPTION
# Scope 

Small PR to clean up the docstring in `calculated_fitted_velocities()`, and remove the `len_factor' input which isn't used anywhere in the function (probably a holdover from this code was in `plot_mapdata()'. The datatypes for `mlats`, `mlons`, and `fit_coefficient` were changed to arrays from lists, because the code doesn't actually work if you give it a list.

## Approval

**Number of approvals:** 1

## Test

```python
import pydarn
import numpy as np

mapfile = 'path/to/mapfile'
SDarn_read = pydarn.SuperDARNRead(mapfile)
map_data = SDarn_read.read_map()

record = map_data[0]  # first record of the file
mlats = np.array([60,70,80])
mlons = np.array([-120,-120,-120])
fit_coefficient = record['N+2']
fit_order = record['fit.order']
lat_shift = record['lat.shft']
lon_shift = record['lon.shft']
lat_min = record['latmin']
hemisphere = pydarn.Hemisphere(record['hemisphere'])

mlats = np.array
velocity, azm = (pydarn.Maps.calculated_fitted_velocities(mlats, mlons, fit_coefficient, hemisphere, fit_order, lat_min))
```
