### PR TITLE
FIX: lowlat default value in maps set to 30

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -903,7 +903,7 @@ class Maps():
     @classmethod
     def calculate_potentials(cls, fit_coefficient: list, lat_min: list,
                              lat_shift: int = 0, lon_shift: int = 0,
-                             fit_order: int = 6, lowlat: int = 60,
+                             fit_order: int = 6, lowlat: int = 30,
                              hemisphere: Enum = Hemisphere.North,
                              **kwargs):
         # TODO: No evaluation of coordinate system made! May need if in


### PR DESCRIPTION
# Scope 

This PR amends the lowlat default in calculate_potentials to 30 (which is the default from projections) from 60.

**issue:** #376 

## Approval

**Number of approvals:** 1, 1 liner

## Test

**matplotlib version**:  3.8.2
**Note testers: please indicate what version of matplotlib you are using**
```python
import pydarn
map_file='data/maps/20220101.n.map'
map_data = pydarn.SuperDARNRead(map_file).read_map()
pydarn.Maps.plot_mapdata(map_data,record=521, 
            parameter=pydarn.MapParams.FITTED_VELOCITY,
            lowlat=50, contour_fill=True, reference_vector=250,
            color_vectors=False, coastline=True)
plt.show()
```
Try different and no lowlat kw values - make sure that the contours fill the selected area you have chosen to plot.

