### PR TITLE
FIX: Increase matplotlib version requirement

### DIFF
--- a/pydarn/plotting/color_maps.py
+++ b/pydarn/plotting/color_maps.py
@@ -1,11 +1,5 @@
 import matplotlib
-import packaging
-
-if packaging.version.parse(matplotlib.__version__) < \
-        packaging.version.parse('3.7.0'):
-    from matplotlib import cm
-else:
-    from matplotlib import colormaps as cm
+from matplotlib import colormaps as cm
 
 
 class PyDARNColormaps():

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 install_requires =
     pyyaml
     numpy
-    matplotlib>=3.5.0
+    matplotlib>=3.7.0
     aacgmv2
     pydarnio>=1.1.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 install_requires =
     pyyaml
     numpy
-    matplotlib>=3.3.4
+    matplotlib>=3.5.0
     aacgmv2
     pydarnio>=1.1.0
 


### PR DESCRIPTION
# Scope 

This PR increases the required version of matplotlib from 3.3.4 to 3.5.0 due to the change of the colormap module in matplotlib. (I did the fix for this when 3.6.0 came out with the depreciation warning for the color_maps module but didn't change the rtp module, or maybe that was developed later I'm not sure. Anyway,  I don't think we need to have more complicated imports, we can just up the requirements as the version required is nearly 3 years old anyway)

Note that the cm library is still in use elsewhere for other purposes and only 'colormaps' was depreciated and moved from cm.

**issue:** #373 

## Approval

**Number of approvals:** 1

## Test

**matplotlib version**: 3.5.0, 3.4.2, 3.8.3
**Note testers: please indicate what version of matplotlib you are using**

Install pydarn as you would normally, you can try to install with a matplotlib version lower than 3.5.0 and it should uninstall and install the higher version for you.
Plot an rtp or 

