### PR TITLE
Faster coastline coordinate conversion

### DIFF
--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -23,7 +23,6 @@ Code which generates axis objects for use in plotting functions
 """
 import aacgmv2
 import enum
-import math
 import matplotlib.pyplot as plt
 from matplotlib import axes
 import numpy as np

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -222,7 +222,7 @@ def axis_geological(date, ax: axes.Axes = None,
                     hemisphere: Hemisphere = Hemisphere.North,
                     lowlat: int = 30, grid_lines: bool = True,
                     coastline: bool = False, nightshade: int = 0,
-                    **kwargs):
+                    cartopy_scale: str = '110m', **kwargs):
     """
 
     Sets up the cartopy orthographic plot axis object, for use in
@@ -279,7 +279,7 @@ def axis_geological(date, ax: axes.Axes = None,
         ax.gridlines(draw_labels=True)
 
     if coastline:
-        ax.coastlines()
+        ax.coastlines(resolution=cartopy_scale)
 
     if nightshade:
         refraction_value = -np.degrees(np.arccos(Re / (Re + nightshade)))


### PR DESCRIPTION
# Scope 

This PR changes `geo_coastline_to_mag()` so it works on geometry arrays, rather than iterating over each glat/glon pair individually, when converting to AACGM. The result is a significant speedup.

## Approval

**Number of approvals:** 2

## Test

Taken from https://pydarn.readthedocs.io/en/main/user/fan/, but can be used in any projection where `coastline=True` and Cartopy is installed.

```python

import pydarn


file = "path/to/fitacf/file"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

pydarn.Fan.plot_fan(fitacf_data,
                    scan_index=1, lowlat=60, zmin=-1000, zmax=1000,
                    boundary=True, radar_label=True,
                    groundscatter=True, ball_and_stick=True, len_factor=300,
                    coastline=True, parameter="v")
plt.show()

```
