### PR TITLE
REF: Axes handling for projections - new geomagnetic zoomable plotting

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -244,7 +244,7 @@ class Fan:
         if ranges[0] < ranges[1] - fan_shape[0]:
             ranges[0] = ranges[1] - fan_shape[0] + 1
         rs = beam_corners_lats
-        if projs != Projs.GEO:
+        if projs == Projs.POLAR:
             thetas = np.radians(beam_corners_lons)
         else:
             thetas = beam_corners_lons

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -405,7 +405,7 @@ class Fan:
                             if projs == Projs.GEO:
                                 end_thetas = np.degrees(end_thetas)
                             # Plot sticks!
-                            plt.plot([t_center, end_thetas],
+                            ax.plot([t_center, end_thetas],
                                      [r_center, end_rs],
                                      color=col, zorder=3.0, linewidth=0.5,
                                      transform=transform)

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -321,9 +321,11 @@ class Fan:
 
         if ccrs is None:
             transform = ax.transData
-
         else:
-            transform = ccrs.PlateCarree()
+            if ball_and_stick:
+                transform = ccrs.Geodetic()
+            else:
+                transform = ccrs.PlateCarree()
 
         if not ball_and_stick:
             ax.pcolormesh(thetas, rs,
@@ -347,7 +349,7 @@ class Fan:
                         # Stick only needed for velocity data
                         if parameter == 'v':
                             # Get azimuth in correct coord system
-                            if coords != Coords.GEOGRAPHIC:
+                            if projs == Projs.POLAR:
                                 lat = r_center
                                 lon = np.degrees(t_center)
                             else:
@@ -358,12 +360,8 @@ class Fan:
 
                             # Make sure each coordinate is in correct
                             # units again
-                            if projs != Projs.GEO:
-                                thetas_calc = np.radians(lon)
-                                rs_calc = lat
-                            else:
-                                thetas_calc = np.radians(lon)
-                                rs_calc = lat
+                            thetas_calc = np.radians(lon)
+                            rs_calc = lat
 
                             hemisphere = SuperDARNRadars.radars[stid]\
                                                         .hemisphere
@@ -401,8 +399,8 @@ class Fan:
                             end_thetas = np.arctan2(end_pos_y, end_pos_x)
                             end_rs = end_rs * hemisphere.value
 
-                            # Convert to degrees for geo plots
-                            if projs == Projs.GEO:
+                            # Convert to degrees for geo/mag plots
+                            if projs != Projs.POLAR:
                                 end_thetas = np.degrees(end_thetas)
                             # Plot sticks!
                             ax.plot([t_center, end_thetas],

--- a/pydarn/plotting/grid.py
+++ b/pydarn/plotting/grid.py
@@ -184,7 +184,7 @@ class Grid():
             if ccrs is None:
                 transform = ax.transData
             else:
-                transform = ccrs.PlateCarree()
+                transform = ccrs.Geodetic()
 
             for stid in dmap_data[record]['stid']:
                 fan_rtn = Fan.plot_fov(stid, date, ax=ax, ccrs=ccrs,
@@ -220,10 +220,15 @@ class Grid():
                 (aacgmv2.convert_mlt(coord_lons[0, 0], date) * 15)
             shifted_lons = data_lons - shifted_mlts
 
-            if projs != Projs.GEO:
+            if projs == Projs.POLAR:
                 # Convert to radians for polar plots
                 thetas_calc = np.radians(shifted_lons)
                 thetas = np.radians(shifted_lons)
+                rs = data_lats
+                rs_calc = data_lats
+            elif projs == Projs.MAG:
+                thetas_calc = np.radians(shifted_lons)
+                thetas = shifted_lons
                 rs = data_lats
                 rs_calc = data_lats
             else:
@@ -349,7 +354,7 @@ class Grid():
                 end_rs = end_rs * hemisphere.value
 
                 # Plot the vectors
-                if projs != Projs.GEO:
+                if projs == Projs.POLAR:
                     for i in num_pts:
                         plt.plot([thetas[i], end_thetas[i]],
                                  [rs[i], end_rs[i]], c=cmap(norm(data[i])),

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -27,6 +27,7 @@
 Grid plots, mapped to AACGM coordinates in a polar format
 """
 
+import cartopy.crs as ccrs
 import datetime as dt
 import matplotlib.pyplot as plt
 import numpy as np
@@ -77,7 +78,7 @@ class Maps():
                      hmb: bool = True, boundary: bool = False,
                      radar_location: bool = False, map_info: bool = True,
                      imf_dial: bool = True, reference_vector: int = 500,
-                     projs: Projs = Projs.POLAR, **kwargs):
+                     projs: Projs = Projs.MAG, **kwargs):
         """
         Plots convection maps data points and vectors
 
@@ -160,8 +161,7 @@ class Maps():
                 Default: 500 (vector plotted)
             projs: Enum
                 choice of projection for plot
-                default: Projs.POLAR (polar projection)
-                There is no support for other projections currently
+                default: Projs.MAG (geomagnetic projection)
             kwargs: key=value
                 uses the parameters for plot_fov and projections.axis
 
@@ -193,12 +193,13 @@ class Maps():
         norm = colors.Normalize
         norm = norm(zmin, zmax)
 
-        if projs != Projs.POLAR:
-            raise plot_exceptions.NotImplemented(" Only polar projections"
+        if projs != Projs.MAG:
+            raise plot_exceptions.NotImplemented(" Only projections in"
+                                                 " magnetic coordinates"
                                                  " are implemented for"
                                                  " convection maps."
                                                  " Please set"
-                                                 " projs=Projs.POLAR"
+                                                 " projs=Projs.MAG"
                                                  " to plot a convection map.")
 
         with warnings.catch_warnings():
@@ -207,14 +208,29 @@ class Maps():
             # Needs to find the positions for each
             # Else just call the axis maker: proj
             if boundary or radar_location:
-                for stid in dmap_data[record]['stid']:
-                    fan_rtn = Fan.plot_fov(stid, date, ax=ax,
-                                           boundary=boundary,
+                fan_rtn = Fan.plot_fov(dmap_data[record]['stid'][0], date, ax=ax, projs=projs,
+                                       boundary=boundary,
+                                       plot_extent=[100,100],
+                                       radar_location=radar_location,
+                                       **kwargs)
+                ax = fan_rtn['ax']
+                ccrs = fan_rtn['ccrs']
+                for stid in dmap_data[record]['stid'][1:]:
+                    fan_rtn = Fan.plot_fov(stid, date, ax=ax, projs=projs,
+                                           boundary=boundary, ccrs=ccrs,
+                                           plot_extent=[100,100],
                                            radar_location=radar_location,
                                            **kwargs)
                     ax = fan_rtn['ax']
             else:
-                ax, _ = projs(date, ax=ax, hemisphere=hemisphere, **kwargs)
+                
+                ax, ccrs = projs(date, ax=ax, hemisphere=hemisphere,
+                              plot_extent=[100,100], **kwargs)
+
+        if ccrs is None:
+            transform = ax.transData
+        else:
+            transform = ccrs.Geodetic()
 
         if parameter == MapParams.MODEL_VELOCITY:
             try:
@@ -328,15 +344,15 @@ class Maps():
                         ind = (np.abs(hmblons - rounded_mlon)).argmin()
                         lat_limit = dmap_data[record]['boundary.mlat'][ind]
                         if abs(mlats[i]) >= abs(lat_limit):
-                            plt.plot([mlons[i], end_mlons[i]],
+                            ax.plot([np.degrees(mlons[i]) % 360, np.degrees(end_mlons[i]) % 360],
                                      [mlats[i], end_mlats[i]],
                                      c=cmap(norm(v_mag[i])),
-                                     linewidth=0.5, zorder=5.0)
+                                     linewidth=0.5, zorder=5.0, transform=transform)
                     else:
-                        plt.plot([mlons[i], end_mlons[i]],
+                        ax.plot([np.degrees(mlons[i]) % 360, np.degrees(end_mlons[i]) % 360],
                                  [mlats[i], end_mlats[i]],
                                  c=cmap(norm(v_mag[i])),
-                                 linewidth=0.5, zorder=5.0)
+                                 linewidth=0.5, zorder=5.0, transform=transform)
             else:
                 for i in range(len(v_mag) - 1):
                     if parameter == MapParams.FITTED_VELOCITY:
@@ -354,34 +370,34 @@ class Maps():
                         ind = (np.abs(hmblons - rounded_mlon)).argmin()
                         lat_limit = dmap_data[record]['boundary.mlat'][ind]
                         if abs(mlats[i]) >= abs(lat_limit):
-                            plt.plot([mlons[i], end_mlons[i]],
+                            ax.plot([np.degrees(mlons[i]) % 360, np.degrees(end_mlons[i]) % 360],
                                      [mlats[i], end_mlats[i]], c='#292929',
-                                     linewidth=0.5, zorder=5.0)
+                                     linewidth=0.5, zorder=5.0, transform=transform)
                     else:
-                        plt.plot([mlons[i], end_mlons[i]],
+                        ax.plot([np.degrees(mlons[i]) % 360, np.degrees(end_mlons[i]) % 360],
                                  [mlats[i], end_mlats[i]], c='#292929',
-                                 linewidth=0.5, zorder=5.0)
+                                 linewidth=0.5, zorder=5.0, transform=transform)
 
         # Plot the sock start dots and reference vector if known
         if color_vectors is True:
             if parameter in [MapParams.MODEL_VELOCITY,
                              MapParams.RAW_VELOCITY]:
                 if reference_vector > 0:
-                    plt.scatter(mlons[:-1], mlats[:-1], c=v_mag[:-1], s=2.0,
+                    ax.scatter(np.degrees(mlons[:-1]) % 360, np.degrees(mlats[:-1]), c=v_mag[:-1], s=2.0,
                                 vmin=zmin, vmax=zmax,  cmap=cmap, zorder=5.0,
-                                clip_on=True)
-                    plt.scatter(mlons[-1], mlats[-1], c=v_mag[-1], s=2.0,
+                                clip_on=True, transform=transform)
+                    ax.scatter(np.degrees(mlons[-1]) % 360, np.degrees(mlats[-1]), c=v_mag[-1], s=2.0,
                                 vmin=zmin, vmax=zmax,  cmap=cmap, zorder=5.0,
-                                clip_on=False)
-                    plt.plot([mlons[-1], end_mlons[-1]],
+                                clip_on=False, transform=transform)
+                    ax.plot([np.degrees(mlons[-1]) % 360, np.degrees(end_mlons[-1]) % 360],
                              [mlats[-1], end_mlats[-1]],
-                             c=cmap(norm(v_mag[-1])),
+                             c=cmap(norm(v_mag[-1])), transform=transform,
                              linewidth=0.5, zorder=5.0, clip_on=False)
                     plt.figtext(0.675, 0.15, str(reference_vector) + ' m/s',
                                 fontsize=8)
                 else:
-                    plt.scatter(mlons[:-1], mlats[:-1], c=v_mag[:-1], s=2.0,
-                                vmin=zmin, vmax=zmax,  cmap=cmap, zorder=5.0)
+                    ax.scatter(np.degrees(mlons[:-1]) % 360, mlats[:-1], c=v_mag[:-1], s=2.0,
+                                vmin=zmin, vmax=zmax,  cmap=cmap, zorder=5.0, transform=transform)
             elif parameter is MapParams.FITTED_VELOCITY:
                 # Shift HMB lons to MLT
                 shifted_mlts = dmap_data[record]['boundary.mlon'][0] - \
@@ -396,25 +412,26 @@ class Maps():
                     ind = (np.abs(hmblons - rounded_mlon)).argmin()
                     lat_limit = dmap_data[record]['boundary.mlat'][ind]
                     if abs(mlats[m]) >= abs(lat_limit):
-                        plt.scatter(mlon, mlats[m], color=cmap(norm(v_mag[m])),
-                                    s=2.0, zorder=5.0, clip_on=True)
+                        ax.scatter(np.degrees(mlon) % 360, mlats[m], color=cmap(norm(v_mag[m])),
+                                    s=2.0, zorder=5.0, clip_on=True, transform=transform)
                     else:
-                        plt.scatter(mlon, mlats[m], c='#DDDDDD', s=2.0,
-                                    zorder=5.0, clip_on=True)
+                        ax.scatter(np.degrees(mlon) % 360, mlats[m], c='#DDDDDD', s=2.0,
+                                    zorder=5.0, clip_on=True, transform=transform)
                 if reference_vector > 0:
-                    plt.scatter(mlons[-1], mlats[-1],
-                                color=cmap(norm(v_mag[-1])),
+                    ax.scatter(np.degrees(mlons[-1]) % 360, mlats[-1],
+                                color=cmap(norm(v_mag[-1])), transform=transform,
                                 s=2.0, zorder=5.0, clip_on=False)
-                    plt.plot([mlons[-1], end_mlons[-1]],
+                    ax.plot([np.degrees(mlons[-1]) % 360, np.degrees(end_mlons[-1]) % 360],
                              [mlats[-1], end_mlats[-1]],
-                             c=cmap(norm(v_mag[-1])),
+                             c=cmap(norm(v_mag[-1])), transform=transform,
                              linewidth=0.5, zorder=5.0, clip_on=False)
                     plt.figtext(0.675, 0.15, str(reference_vector) + ' m/s',
                                 fontsize=8)
             # No vector socks on spectral width
             else:
-                plt.scatter(mlons[:], mlats[:], c=v_mag[:], s=2.0,
-                            vmin=zmin, vmax=zmax,  cmap=cmap, zorder=5.0)
+                ax.scatter(np.degrees(mlons[:]), mlats[:], c=v_mag[:], s=2.0,
+                            vmin=zmin, vmax=zmax,  cmap=cmap, zorder=5.0,
+                            transform=transform)
 
         else:
             # no color so make sure colorbar is turned off
@@ -422,18 +439,18 @@ class Maps():
             if parameter in [MapParams.MODEL_VELOCITY,
                              MapParams.RAW_VELOCITY]:
                 if reference_vector > 0:
-                    plt.scatter(mlons[:-1], mlats[:-1], c='#292929', s=2.0,
-                                zorder=5.0, clip_on=True)
-                    plt.scatter(mlons[-1], mlats[-1], c='#292929', s=2.0,
-                                zorder=5.0, clip_on=False)
-                    plt.plot([mlons[-1], end_mlons[-1]],
+                    ax.scatter(np.degrees(mlons[:-1]) % 360, mlats[:-1], c='#292929', s=2.0,
+                                zorder=5.0, clip_on=True, transform=transform)
+                    ax.scatter(np.degrees(mlons[-1]) % 360, mlats[-1], c='#292929', s=2.0,
+                                zorder=5.0, clip_on=False, transform=transform)
+                    ax.plot([np.degrees(mlons[-1]) % 360, np.degrees(end_mlons[-1])],
                              [mlats[-1], end_mlats[-1]], c='#292929',
-                             linewidth=0.5, zorder=5.0, clip_on=False)
+                             linewidth=0.5, zorder=5.0, clip_on=False, transform=transform)
                     plt.figtext(0.675, 0.15, str(reference_vector) + ' m/s',
                                 fontsize=8)
                 else:
-                    plt.scatter(mlons[:-1], mlats[:-1], c='#292929', s=2.0,
-                                zorder=5.0)
+                    ax.scatter(np.degrees(mlons[:-1]) % 360, np.degrees(mlats[:-1]), c='#292929', s=2.0,
+                                zorder=5.0, transform=transform)
             elif parameter is MapParams.FITTED_VELOCITY:
                 # Shift HMB lons to MLT
                 shifted_mlts = dmap_data[record]['boundary.mlon'][0] - \
@@ -448,23 +465,23 @@ class Maps():
                     ind = (np.abs(hmblons - rounded_mlon)).argmin()
                     lat_limit = dmap_data[record]['boundary.mlat'][ind]
                     if abs(mlats[m]) >= abs(lat_limit):
-                        plt.scatter(mlon, mlats[m], c='#292929', s=2.0,
-                                    zorder=5.0, clip_on=True)
+                        ax.scatter(rounded_mlon, mlats[m], c='#292929', s=2.0,
+                                    zorder=5.0, clip_on=True, transform=transform)
                     else:
-                        plt.scatter(mlon, mlats[m], c='#DDDDDD', s=2.0,
-                                    zorder=5.0, clip_on=True)
+                        ax.scatter(rounded_mlon, mlats[m], c='#DDDDDD', s=2.0,
+                                    zorder=5.0, clip_on=True, transform=transform)
                 if reference_vector > 0:
-                    plt.scatter(mlons[-1], mlats[-1], c='#292929', s=2.0,
-                                zorder=5.0, clip_on=False)
-                    plt.plot([mlons[-1], end_mlons[-1]],
+                    ax.scatter(np.degrees(mlons[-1]) % 360, mlats[-1], c='#292929', s=2.0,
+                                zorder=5.0, clip_on=False, transform=transform)
+                    ax.plot([np.degrees(mlons[-1]) % 360, np.degrees(end_mlons[-1])],
                              [mlats[-1], end_mlats[-1]], c='#292929',
-                             linewidth=0.5, zorder=5.0, clip_on=False)
+                             linewidth=0.5, zorder=5.0, clip_on=False, transform=transform)
                     plt.figtext(0.675, 0.15, str(reference_vector) + ' m/s',
                                 fontsize=8)
             # No vector socks on spectral width
             else:
-                plt.scatter(mlons[:], mlats[:], c='#292929', s=2.0,
-                            zorder=5.0)
+                ax.scatter(np.degrees(mlons[:]) % 360, mlats[:], c='#292929', s=2.0,
+                            zorder=5.0, transform=transform)
 
         if colorbar is True:
             mappable = cm.ScalarMappable(norm=norm, cmap=cmap)
@@ -508,6 +525,7 @@ class Maps():
                                         fit_order=fit_order,
                                         hemisphere=hemisphere,
                                         contour_colorbar=contour_colorbar,
+                                        transform=transform,
                                         **kwargs)
 
         if hmb is True:
@@ -516,7 +534,8 @@ class Maps():
             mlons_hmb = dmap_data[record]['boundary.mlon']
             hmb_lon, hmb_lat = cls.plot_heppner_maynard_boundary(mlats_hmb,
                                                                  mlons_hmb,
-                                                                 date)
+                                                                 date,
+                                                                 transform=transform)
         else:
             hmb_lon = None
             hmb_lat = None
@@ -814,7 +833,8 @@ class Maps():
 
     @classmethod
     def plot_heppner_maynard_boundary(cls, mlats: list, mlons: list,
-                                      date: object, line_color: str = 'black',
+                                      date: object, transform: object = None, 
+                                      line_color: str = 'black',
                                       **kwargs):
         # TODO: No evaluation of coordinate system made! May need if in
         # plotting to plot in radians/geo ect.
@@ -840,9 +860,10 @@ class Maps():
         shifted_mlts = mlons[0] - \
             (aacgmv2.convert_mlt(mlons[0], date) * 15)
         shifted_lons = mlons - shifted_mlts
-        mlon = np.radians(shifted_lons)
+        mlon = shifted_lons % 360
 
-        plt.plot(mlon, mlats, c=line_color, zorder=4.0, **kwargs)
+        plt.plot(mlon, mlats, c=line_color, zorder=4.0, transform=transform,
+                 **kwargs)
         return mlon, mlats
 
     @classmethod
@@ -1113,6 +1134,7 @@ class Maps():
                                 pot_minmax_color: str = 'k',
                                 pot_zmin: int = -50,
                                 pot_zmax: int = 50,
+                                transform: object = None,
                                 **kwargs):
         # TODO: No evaluation of coordinate system made! May need if in
         # plotting to plot in radians/geo ect.
@@ -1206,7 +1228,7 @@ class Maps():
         shifted_mlts = mlon_u[0, 0] - \
             (aacgmv2.convert_mlt(mlon_u[0, 0], date) * 15)
         shifted_lons = mlon_u - shifted_mlts
-        mlon = shifted_lons
+        mlon = shifted_lons % 360
 
         # Contained in function as too long to go into the function call
         if contour_levels == []:
@@ -1229,11 +1251,11 @@ class Maps():
             # Filled contours
             norm = colors.Normalize
             norm = norm(pot_zmin, pot_zmax)
-            cs = plt.contourf(np.radians(mlon), mlat, pot_arr, 2,
+            cs = plt.contourf(mlon, mlat, pot_arr, 2,
                               norm=norm, vmax=pot_zmax, vmin=pot_zmin,
                               levels=np.array(contour_levels),
                               cmap=contour_fill_cmap, alpha=0.5,
-                              extend='both', zorder=3.0)
+                              extend='both', zorder=3.0, transform=ccrs.PlateCarree())
             if contour_colorbar is True:
                 mappable = cm.ScalarMappable(norm=norm, cmap=contour_fill_cmap)
                 locator = ticker.MaxNLocator(symmetric=True, min_n_ticks=3,
@@ -1248,11 +1270,12 @@ class Maps():
                 cb_contour = None
         else:
             # Contour lines only
-            cs = plt.contour(np.radians(mlon), mlat, pot_arr, 2,
+            cs = plt.contour(mlon, mlat, pot_arr, 2,
                              vmax=pot_zmax, vmin=pot_zmin,
                              levels=np.array(contour_levels),
                              colors=contour_color, alpha=0.8,
-                             linewidths=contour_linewidths, zorder=3.0)
+                             linewidths=contour_linewidths, zorder=3.0,
+                             transform=ccrs.PlateCarree())
             cb_contour = None
             # TODO: Add in contour labels
             # if contour_label:

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -161,8 +161,10 @@ def axis_geomagnetic(date, ax: axes.Axes = None, lowlat: int = 30,
             Altitude above surface for calculating regions shadowed from Sun.
         plot_center: list [float, float]
             Longitude and Latitude of the desired center of the plot
-            Plot will still plot if data is on the other side of the Earth
+            Plot will still plot even if data is on the other side of the Earth
             Remember to include negative latitude for Southern Hemisphere
+            Setting this option will change the rotation and 12 MLT may no
+            longer be at the bottom of the plot
             Default: None
             Example: [-90, 60] will show the Earth centered on Canada
         plot_extent: list [float, float]
@@ -177,19 +179,17 @@ def axis_geomagnetic(date, ax: axes.Axes = None, lowlat: int = 30,
         raise plot_exceptions.CartopyMissingError()
     if cartopyVersion is False:
         raise plot_exceptions.CartopyVersionError(cartopy.__version__)
-    # no need to shift any coords, let cartopy do that
-    # however, we do need to figure out
-    # how much to rotate the projection
-    deg_from_midnight = (date.hour + date.minute / 60) / 24 * 360
     if plot_center is None:
         # If no center for plotting is given, default to pole
         if hemisphere == Hemisphere.North:
             pole_lat = 90
-            lon = -deg_from_midnight
+            # Keep 12 MLT at the bottom of plot by default
+            lon = 180
             lat = abs(lowlat)
         else:
             pole_lat = -90
-            lon = 360 - deg_from_midnight
+            # Keep 12 MLT at the bottom of plot by default
+            lon = 0
             lat = -abs(lowlat)
         if ax is None:
             proj = ccrs.Orthographic(lon, pole_lat)

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -287,6 +287,9 @@ def axis_geomagnetic_polar(date, ax: axes.Axes = None, lowlat: int = 30,
     various other functions. Magnetic latitude - magnetic local
     time projection.
 
+    This projection is defunct now MAG exists, however is kept available for
+    compatibility and non-cartopy options. 
+
     Parameters
     -----------
         date: datetime object
@@ -429,19 +432,16 @@ def axis_geographic(date, ax: axes.Axes = None,
         raise plot_exceptions.CartopyMissingError()
     if cartopyVersion is False:
         raise plot_exceptions.CartopyVersionError(cartopy.__version__)
-    # no need to shift any coords, let cartopy do that
-    # however, we do need to figure out
-    # how much to rotate the projection
-    deg_from_midnight = (date.hour + date.minute / 60) / 24 * 360
     if plot_center is None:
-        # If no center for plotting is given, default to pole
+        # If no center for plotting is given, default to pole and rotate for 0
+        # degrees longitude
         if hemisphere == Hemisphere.North:
             pole_lat = 90
-            lon = -deg_from_midnight
+            lon = 0
             lat = abs(lowlat)
         else:
             pole_lat = -90
-            lon = 360 - deg_from_midnight
+            lon = 0
             lat = -abs(lowlat)
         if ax is None:
             proj = ccrs.Orthographic(lon, pole_lat)

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -183,13 +183,13 @@ def axis_geomagnetic(date, ax: axes.Axes = None, lowlat: int = 30,
         # If no center for plotting is given, default to pole
         if hemisphere == Hemisphere.North:
             pole_lat = 90
-            # Keep 12 MLT at the bottom of plot by default
-            lon = 180
+            # Keep 0 MLT at the bottom of plot by default
+            lon = 0
             lat = abs(lowlat)
         else:
             pole_lat = -90
-            # Keep 12 MLT at the bottom of plot by default
-            lon = 0
+            # Keep 0 MLT at the bottom of plot by default
+            lon = 180
             lat = -abs(lowlat)
         if ax is None:
             proj = ccrs.Orthographic(lon, pole_lat)

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -255,10 +255,12 @@ def axis_geographic(date, ax: axes.Axes = None,
             Altitude above surface for calculating regions shadowed from Sun.
         plot_center: list [float, float]
             Longitude and Latitude of the desired center of the plot
+            Plot will still plot if data is on the other side of the Earth
+            Remember to include negative latitude for Southern Hemisphere
             Default: None
             Example: [-90, 60] will show the Earth centered on Canada
         plot_extent: list [float, float]
-            Plotting extent in terms of a percentatge of Earth shown in
+            Plotting extent in terms of a percentage of Earth shown in
             the x and y plotting field 
             Default: None
             Example: [30, 50] shows a plot centered on the pole or specified

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -9,6 +9,8 @@
 # 2022-06-13 Elliott Day don't create new ax if ax passed in to Projs
 # 2023-02-22 CJM added options for nightshade
 # 2023-08-11 RR added crude check for unmodified axes, handle both hemispheres
+# 2024-05-15 CJM refactored geographic axes to add plot zoom and center, 
+#            and added the geomagnetic version to do the same
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md

--- a/pydarn/plotting/projections.py
+++ b/pydarn/plotting/projections.py
@@ -191,7 +191,7 @@ def axis_geomagnetic(date, ax: axes.Axes = None, lowlat: int = 30,
             lat = -abs(lowlat)
         if ax is None:
             proj = ccrs.Orthographic(lon, pole_lat)
-            ax = plt.subplot(111, projection=proj, aspect='auto')
+            ax = plt.axes(projection=proj)
             if plot_extent is not None and len(plot_extent) == 2:
                 # Padding in % of Earth radius
                 padx = (plot_extent[0] / 100) * Re*1000
@@ -200,13 +200,14 @@ def axis_geomagnetic(date, ax: axes.Axes = None, lowlat: int = 30,
             else:
                 extent = abs(proj.transform_point(lon, lat, ccrs.PlateCarree())[1])
                 ax.set_extent(extents=(-extent, extent, -extent, extent), crs=proj)
+
     else:
         # If the center of the plot is given- shift it around
         lon = plot_center[0]
         lat = plot_center[1]
         if ax is None:
             proj = ccrs.Orthographic(lon, lat)
-            ax = plt.subplot(111, projection=proj, aspect='auto')
+            ax = plt.axes(projection=proj)
             if plot_extent is not None and len(plot_extent) == 2:
                 # Padding in % of Earth radius
                 padx = (plot_extent[0] / 100) * Re*1000
@@ -442,7 +443,7 @@ def axis_geographic(date, ax: axes.Axes = None,
             lat = -abs(lowlat)
         if ax is None:
             proj = ccrs.Orthographic(lon, pole_lat)
-            ax = plt.subplot(111, projection=proj, aspect='auto')
+            ax = plt.axes(projection=proj)
             if plot_extent is not None and len(plot_extent) == 2:
                 # Padding in % of Earth radius
                 padx = (plot_extent[0] / 100) * Re*1000
@@ -457,7 +458,7 @@ def axis_geographic(date, ax: axes.Axes = None,
         lat = plot_center[1]
         if ax is None:
             proj = ccrs.Orthographic(lon, lat)
-            ax = plt.subplot(111, projection=proj, aspect='auto')
+            ax = plt.axes(projection=proj)
             if plot_extent is not None and len(plot_extent) == 2:
                 # Padding in % of Earth radius
                 padx = (plot_extent[0] / 100) * Re*1000


### PR DESCRIPTION
# Scope 

This PR amends some details in the projections module, updates the geographic plotting to allow the user to zoom in on areas and move the focus of the plot. A new projection is also made for the same thing in geomagnetic/MLT coordinates.
I was unable to allow subplot usage with these plots - the projections are very specific for use with SuperDARN data so I don't recommend making your own axes to put in, it would be nice to have the ability to plot multiple plots on one figure, but that will require a lot of work that I can't do right now.

Zoomable convection map plots will come eventually - they're just very hard and there are a few issues I haven't solved yet so that will all be in another PR at a later date!

Whats new:
- New MAG projection: I've absolutely shredded cartopy to make this happen, but you can plot in mlat, MLT plots using the new projection. The magnetic POLAR projection is kept for use with convection maps at the moment as this is set up nicely.
- You can now use the keywords plot_extent and plot_center to center and zoom in on an area of the plot if using the MAG or GEO projections! plot_center is in geo or mag lat/lon depending on projection chosen, plot_extent is in how much of the Earth you want in the x and y plotting plane to be shown. See testing details for examples.

```
plot_center: list [float, float]
            Longitude and Latitude of the desired center of the plot
            Plot will still plot if data is on the other side of the Earth
            Remember to include negative latitude for Southern Hemisphere
            Default: None
            Example: [-90, 60] will show the Earth centered on Canada
plot_extent: list [float, float]
            Plotting extent in terms of a percentage of Earth shown in
            the x and y plotting field 
            Default: None
            Example: [30, 50] shows a plot centered on the pole or specified
                     plot_center coord that shows 30% of the Earth in x and 
                     50% of the Earth in y. See tutorials for plotted example.
```

**issue:** to close #357 

## Approval

**Number of approvals:** 2 at least please, lots of things to test

## Test

**matplotlib version**: 3.8.2
**Note testers: please indicate what version of matplotlib you are using**

Also test with southern hemisphere data, different keyword combos etc...

### FAN or BALL AND STICK Plot testing:
This tests the new geographic plotting and geomagnetic plotting defaults and zoom features

```python
import matplotlib.pyplot as plt
import pydarn
import datetime as dt

SDarn_read = pydarn.SuperDARNRead('/Users/carley/Documents/data/20200101.0001.00.inv.fitacf')
fitacf_data = SDarn_read.read_fitacf()    
rtn = pydarn.Fan.plot_fan(fitacf_data, scan_index=50, coastline=True,
                        radar_label=True, groundscatter=True, colorbar=False,
                        coords=pydarn.Coords.GEOGRAPHIC, projs=pydarn.Projs.GEO,
                        plot_extent=[80,80], plot_center=[-120,75])
    plt.title('Geographic plot-extent: 80,80 plot-center: -120,75')
    plt.show()
    rtn = pydarn.Fan.plot_fan(fitacf_data, scan_index=100, coastline=True,
                        radar_label=True, groundscatter=True, colorbar=False,
                        coords=pydarn.Coords.GEOGRAPHIC, projs=pydarn.Projs.GEO)
                        
    plt.title('Geographic default')
    plt.show()

    rtn = pydarn.Fan.plot_fan(fitacf_data, scan_index=50, coastline=True,
                        radar_label=True, groundscatter=True, colorbar=False,
                        coords=pydarn.Coords.AACGM_MLT, projs=pydarn.Projs.MAG,
                        plot_extent=[80,80], plot_center=[-120,75])
                        
    plt.title('Geomagnetic plot-extent: 80,80 plot-center: -120,75')
    plt.show()
    rtn = pydarn.Fan.plot_fan(fitacf_data, scan_index=100, coastline=True,
                        radar_label=True, groundscatter=True, colorbar=False,
                        coords=pydarn.Coords.AACGM_MLT, projs=pydarn.Projs.MAG)
    plt.title('Geomagnetic default')
    plt.show()
```
<img width="650" alt="Screenshot 2024-05-15 at 10 53 03 AM" src="https://github.com/SuperDARN/pydarn/assets/60905856/689adbe2-752a-44f4-8446-ccad3b472a7e">
<img width="523" alt="Screenshot 2024-05-15 at 10 54 32 AM" src="https://github.com/SuperDARN/pydarn/assets/60905856/a01a5db8-833c-4fab-a61d-e31eabbe10b1">
<img width="691" alt="Screenshot 2024-05-15 at 10 53 21 AM" src="https://github.com/SuperDARN/pydarn/assets/60905856/c2102285-2e7f-40b9-998f-55bfea7ca44e">
<img width="583" alt="Screenshot 2024-05-15 at 10 55 26 AM" src="https://github.com/SuperDARN/pydarn/assets/60905856/bc1eba40-0b23-40ac-8045-9af5cf86e790">

### FOV plot testing:
This feature was specifically requested for plotting the new NSSC radars, so here is an example of doing jsut that in magnetic MLT coordinates.

```python
import pydarn
from datetime import datetime
import matplotlib.pyplot as plt
stids = [51,52,53,54,55,56]
cols = ['salmon','salmon','gold','gold','cornflowerblue','cornflowerblue']
plt.figure(figsize=(8, 8))
rtn=pydarn.Fan.plot_fov(stids[0], datetime(2021, 2, 5, 18, 5),
                        fov_color= cols[0],radar_location=True,
                        radar_label=True, coastline=True,
                        coords=pydarn.Coords.AACGM_MLT, projs=pydarn.Projs.MAG,
                        plot_extent=[90,50], plot_center=[20,60])

for i, stid in enumerate(stids[1:]):
    rtn=pydarn.Fan.plot_fov(stid, datetime(2021, 2, 5, 18, 5), ax=rtn['ax'],
                            ccrs=rtn['ccrs'], fov_color= cols[i+1],
                            radar_location=True, radar_label=True,
                            coastline=True,
                        coords=pydarn.Coords.AACGM_MLT, projs=pydarn.Projs.MAG)
plt.show()
```
<img width="910" alt="Screenshot 2024-05-15 at 10 40 29 AM" src="https://github.com/SuperDARN/pydarn/assets/60905856/d5a7d6bb-9614-42ed-8fd9-9dcc4ae268cf">

### GRID plotting:
```python
import matplotlib.pyplot as plt 
import datetime as dt
import pydarn

grid_file_s = "/Users/carley/Documents/data/grids/20150308.south.grid2"
grid_file = "/Users/carley/Documents/data/grids/20150301.2001.00.inv.grid"
grid_data = pydarn.SuperDARNRead(grid_file).read_grid()
grid_data_s = pydarn.SuperDARNRead(grid_file_s).read_grid()

pydarn.Grid.plot_grid(grid_data, record=10, coastline=True, lowlat=30,
                        coords=pydarn.Coords.AACGM_MLT, projs=pydarn.Projs.MAG)

plt.show()

pydarn.Grid.plot_grid(grid_data, record=10, coastline=True, lowlat=30,
                        coords=pydarn.Coords.AACGM_MLT, projs=pydarn.Projs.POLAR)

plt.show()

pydarn.Grid.plot_grid(grid_data, record=10, coastline=True, lowlat=30,
                        coords=pydarn.Coords.GEOGRAPHIC, projs=pydarn.Projs.GEO)

plt.show()

pydarn.Grid.plot_grid(grid_data_s, record=10, coastline=True, lowlat=30,
                        coords=pydarn.Coords.AACGM_MLT, projs=pydarn.Projs.MAG)

plt.show()

pydarn.Grid.plot_grid(grid_data_s, record=10, coastline=True, lowlat=30,
                        coords=pydarn.Coords.AACGM_MLT, projs=pydarn.Projs.POLAR)

plt.show()

pydarn.Grid.plot_grid(grid_data_s, record=10, coastline=True, lowlat=30,
                        coords=pydarn.Coords.GEOGRAPHIC, projs=pydarn.Projs.GEO)

plt.show()
```

Map plots only use the Polar projection.


