### PR TITLE
NEW: Map Potential Time Series at Given MLON/MLAT

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -463,7 +463,7 @@ class Fan:
             title = Fan.__add_title__(start_time, end_time)
             ax.set_title(title)
         # Determine embargo status
-        cls.__determine_embargo(time2datetime(dmap_data[plot_beams[-1][-1]])
+        #cls.__determine_embargo(time2datetime(dmap_data[plot_beams[-1][-1]])
         return {'ax': ax,
                 'ccrs': ccrs,
                 'cm': cmap,

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -12,6 +12,7 @@
 # 2022-08-15: CJM - Removed plot_FOV call for default uses
 # 2022-12-13: CJM - Limited reference vectors to only velocity use
 # 2023-06-28: CJM - Refactored return values
+# 2024-07-11: CJM - Added potential time series plot
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -70,7 +70,7 @@ class Maps():
                      record: int = 0, start_time: dt.datetime = None,
                      time_delta: float = 1,  alpha: float = 1.0,
                      len_factor: float = 150, color_vectors: bool = True,
-                     cmap: str = None, colorbar: bool = True, 
+                     cmap: str = None, colorbar: bool = True,
                      contour_colorbar: bool = True,
                      colorbar_label: str = '', title: str = '',
                      zmin: float = None, zmax: float = None,
@@ -1326,7 +1326,9 @@ class Maps():
                          parameter: Enum = TimeSeriesParams.NUM_VECTORS,
                          start_record: int = 0, end_record: int = 1,
                          start_time: dt.datetime = None,
-                         end_time: dt.datetime = None, ax=None, **kwargs):
+                         end_time: dt.datetime = None,
+                         potential_position: list = [],
+                         ax=None, **kwargs):
         '''
         Plot time series of various map parameters
 
@@ -1342,6 +1344,8 @@ class Maps():
             Start time of the data
         end_time: dt.datetime
             End time of the data
+        potential_position: list [mlon, mlat]
+            Position at which the potential is to be calculated and plotted
         ax:
             matplotlib axis
         kwargs:
@@ -1368,7 +1372,11 @@ class Maps():
             for records in range(start_record, end_record):
                 # append the dimension of numv for each record
                 # we can just uexse any of the keys with dimensionality numv
-                datalist.append(len(dmap_data[records]['vector.mlat']))
+                # Try loop for partial records
+                try:
+                    datalist.append(len(dmap_data[records]['vector.mlat']))
+                except KeyError:
+                    datalist.append(np.nan)
                 # now get the associated time data point per record
                 timelist.append(time2datetime(dmap_data[records]))
             plt.plot(timelist, datalist, **kwargs)
@@ -1376,6 +1384,45 @@ class Maps():
             plt.xlabel('Time (UTC)')
             plt.title("Number of Vectors for " + str(start_time)
                       + " to " + str(end_time))
+        elif parameter == TimeSeriesParams.POT:
+            # This requires a position input in [mlat, mlon]
+            if len(potential_position) != 2:
+                warnings.warn("A valid magnetic position with format "
+                              "[mlon, mlat] "
+                              "is required to plot the potential "
+                              "at a given location. E.G. "
+                              "potential_position = [-110, 78]")
+            elif (potential_position[0] <= -180 or
+                  potential_position[0] >= 180 or
+                  potential_position[1] <= -90 or
+                  potential_position[1] >= 90):
+                warnings.warn("A valid magnetic position with format "
+                              "[mlon, mlat] "
+                              "is required to plot the potential "
+                              "at a given location. E.G. "
+                              "potential_position = [-110, 78]")
+            else:
+                datalist = []
+                timelist = []
+                for records in range(start_record, end_record):
+                    # Calculate potential
+                    pot = cls.calculate_potentials_pos(
+                            potential_position[1],
+                            potential_position[0],
+                            dmap_data[records]['N+2'],
+                            dmap_data[records]['latmin'],
+                            dmap_data[records]['lat.shft'],
+                            dmap_data[records]['lon.shft'],
+                            dmap_data[records]['fit.order'],
+                            Hemisphere(dmap_data[records]['hemisphere']))
+                    datalist.append(pot)
+                    timelist.append(time2datetime(dmap_data[records]))
+                plt.plot(timelist, datalist, **kwargs)
+                plt.ylabel('Potential (kV)')
+                plt.xlabel('Time (UTC)')
+                plt.title('Potential at ' + str(potential_position) +
+                          ' for ' + str(start_time) + " to " +
+                          str(end_time))
         elif parameter is not None:
             datalist = []
             timelist = []

--- a/pydarn/utils/plotting.py
+++ b/pydarn/utils/plotting.py
@@ -162,8 +162,8 @@ def time2datetime(dmap_record: dict) -> dt.datetime:
         hour = dmap_record['start.hour']
         minute = dmap_record['start.minute']
         second = dmap_record['start.second']
-        return datetime(year=year, month=month, day=day, hour=hour,
-                        minute=minute, second=int(second))
+        return dt.datetime(year=year, month=month, day=day, hour=hour,
+                           minute=minute, second=int(second))
 
 
 def add_embargo(fig: plt.Figure):

--- a/pydarn/utils/plotting.py
+++ b/pydarn/utils/plotting.py
@@ -58,7 +58,8 @@ class TimeSeriesParams(enum.Enum):
         KP = 'IMF.Kp'
         LATMINN = 'latmin'
         ERR = 'chi.sqr.dat'
-        CPP = 'pot.drop'     
+        CPP = 'pot.drop'
+        POT = 'pot.pos'
         
 
 def find_record(dmap_data: List[dict], start_time: datetime, time_delta:int = 1):


### PR DESCRIPTION
# Scope 

This PR includes the addition of a time series plot option for plotting the potential calculated at a specific mlon, mlat in a map potential.

**issue:** to close #368 

## Approval

**Number of approvals:** 2

## Test

**matplotlib version**: 3.9.1

NOTE THERE IS A NUMPY BUG IN PYDARNIO, DOWNGRADE NUMPY TO 1.26.4 OR BELOW, PLEASE TEST IN A VIRTUAL ENVIRONMENT. This is out of scope for pyDARN and will be fixed in pyDARNio later.  

**Note testers: please indicate what version of matplotlib you are using**

``` python
import pydarn
import datetime as dt
import matplotlib.pyplot as plt


mapfile = '/Users/carley/Documents/data/maps/20220101.n.map'

SDarn_read = pydarn.SuperDARNRead(mapfile)
map_data = SDarn_read.read_map()


# Coordinates of interest, as mlat/mlon pairs. 
#This example keeps mlon the same but changes mlat, like a keogram
mlats = 75
mlons = 110

# Map parameters from the mapfile, first record
fit_coefficient = map_data[0]['N+2']
fit_order = map_data[0]['fit.order']
lat_shift = map_data[0]['lat.shft']
lon_shift = map_data[0]['lon.shft']
lat_min = map_data[0]['latmin']
hemisphere = pydarn.Hemisphere(map_data[0]['hemisphere'])

# Get the potential for my coordinates
pots = pydarn.Maps.calculate_potentials_pos(mlats, mlons, fit_coefficient,
                                            lat_min, lat_shift, lon_shift,
                                            fit_order, hemisphere)
                                            
print(pots)

# Test plotting
pydarn.Maps.plot_time_series(map_data,
                         parameter = pydarn.TimeSeriesParams.POT,
                         start_time = dt.datetime(2022,1,1,0,0),
                         end_time = dt.datetime(2022,1,1,6,0),
                         potential_position = [mlons, mlats])
plt.show()

# Test warning messages
pydarn.Maps.plot_time_series(map_data,
                         parameter = pydarn.TimeSeriesParams.POT,
                         start_time = dt.datetime(2022,1,1,0,0),
                         end_time = dt.datetime(2022,1,1,6,0),
                         potential_position = [])
plt.show()
pydarn.Maps.plot_time_series(map_data,
                         parameter = pydarn.TimeSeriesParams.POT,
                         start_time = dt.datetime(2022,1,1,0,0),
                         end_time = dt.datetime(2022,1,1,6,0),
                         potential_position = [-10000, 6])
plt.show()

# Test fix for partial records
pydarn.Maps.plot_time_series(map_data,
                             parameter=pydarn.TimeSeriesParams.NUM_VECTORS,
                             start_record=0, end_record=100)
plt.show()
```
You should get two plots:
<img width="880" alt="Screenshot 2024-07-11 at 10 38 41 AM" src="https://github.com/SuperDARN/pydarn/assets/60905856/e8b267d6-1078-4f9b-8122-f837482c7fa5">
<img width="918" alt="Screenshot 2024-07-11 at 10 38 49 AM" src="https://github.com/SuperDARN/pydarn/assets/60905856/67f51f15-a204-4a03-b377-21dcc24de85d">

and a console output of:
```
[13.60432699]
/Users/carley/Documents/testing/venv-map-pot-time-series/lib/python3.9/site-packages/pydarn/plotting/maps.py: 1390: UserWarning: A valid magnetic position with format [mlon, mlat] is required to plot the potential at a given location. E.G. potential_position = [-110, 78]
/Users/carley/Documents/testing/venv-map-pot-time-series/lib/python3.9/site-packages/pydarn/plotting/maps.py: 1399: UserWarning: A valid magnetic position with format [mlon, mlat] is required to plot the potential at a given location. E.G. potential_position = [-110, 78]
```
