### PR TITLE
EHN: Fan Plot using User Input Data

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -44,6 +44,7 @@ Fan plots, mapped to AACGM coordinates in a polar format
 import datetime as dt
 import matplotlib.pyplot as plt
 import numpy as np
+import warnings
 
 from matplotlib import ticker, cm, colors, axes
 from typing import List, Union

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -463,7 +463,7 @@ class Fan:
             title = Fan.__add_title__(start_time, end_time)
             ax.set_title(title)
         # Determine embargo status
-        cls.__determine_embargo(time2datetime(dmap_data[plot_beams[-1][-1]])
+        #cls.__determine_embargo(time2datetime(dmap_data[plot_beams[-1][-1]])
         return {'ax': ax,
                 'ccrs': ccrs,
                 'cm': cmap,
@@ -475,6 +475,188 @@ class Fan:
                          'ground_scatter': grndsct}
                 }
 
+
+    @staticmethod
+    def plot_fan_input(data_array: list = [], data_datetime: dt.datetime = [], 
+                 ax: object = None, stid: int = None, data_groundscatter: list = [], 
+                 rsep: int = 45, frang: int = 180,
+                 data_parameter: str = 'v', cmap: str = None, zmin: int = None,
+                 zmax: int = None, colorbar: bool = True,
+                 colorbar_label: str = '', cax=None, boundary: bool = True,
+                 projs: Projs = Projs.POLAR,
+                 coords: Coords = Coords.AACGM_MLT, **kwargs):
+        """
+        Plots a radar's Field Of View (FOV) fan plot for the given data and
+        scan number
+
+        Parameters
+        -----------
+            data_array: List[ranges, gates]
+                Array of data, must be in shape of standard fan plot
+            data_datetime: datetime object
+                Time at which data is taken or wanted to be plotted
+            ax: axes.Axes
+                Pre-defined axis object to pass in, must currently be
+                polar projection
+                Default: Generates a polar projection for the user
+                with MLT/latitude labels
+            data_groundscatter: list[beams, ranges]
+                Boolean array of same size which denotes groundscatter
+            stid: int
+                StationID of the radar of interest
+            data_parameter: str
+                Key name indicating which parameter to plot.
+                Default: v (Velocity). Alternatives: 'p_l', 'w_l', 'elv'
+                Used to grab default colourmaps
+            cmap: matplotlib.cm
+                matplotlib colour map
+                https://matplotlib.org/tutorials/colors/colormaps.html
+                Default: Official pyDARN colour map for given parameter
+            zmin: int
+                The minimum parameter value for coloring
+                Default: {'p_l': [0], 'v': [-200], 'w_l': [0], 'elv': [0]}
+            zmax: int
+                The maximum parameter value for  coloring
+                Default: {'p_l': [50], 'v': [200], 'w_l': [250], 'elv': [50]}
+            colorbar: bool
+                Draw a colourbar if True
+                Default: True
+            colorbar_label: str
+                the label that appears next to the colour bar.
+                Requires colorbar to be true
+                Default: ''
+            cax: axes.Axes
+                Pre-defined axis for the colorbar. If not specified and colorbar
+                is True, a new axis will be created.
+            boundary: bool
+                if true then plots the FOV boundaries
+                default: true
+            projs: Enum
+                choice of projection for plot
+                default: Projs.POLAR (polar projection)
+            coords: Enum
+                choice of plotting coordinates
+                default: Coords.AACGM_MLT (Magnetic Lat and MLT)
+            kwargs: key = value
+                Additional keyword arguments to be used in projection plotting
+                and plot_fov for possible keywords, see: projections.axis_polar
+
+        Returns
+        -----------
+        beam_corners_aacgm_lats
+            n_beams x n_gates numpy array of latitudes
+            return values dependent on given coords enum
+        beam_corners_aacgm_lons
+            n_beams x n_gates numpy array of longitudes or MLT
+            return values dependent on given coords enum
+
+        See Also
+        --------
+            plot_fov
+        """
+        beam_corners_lats, beam_corners_lons =\
+            coords(stid=stid, rsep=rsep, frang=frang,
+                   gates=[0, len(data_array)], date=data_datetime,
+                   **kwargs)
+
+        fan_shape = beam_corners_lons.shape
+
+        rs = beam_corners_lats
+        if projs != Projs.GEO:
+            thetas = np.radians(beam_corners_lons)
+        else:
+            thetas = beam_corners_lons
+
+        scan = data_array
+        grndsct = data_groundscatter
+
+        # Colour table and max value selection depending on parameter plotted
+        # Load defaults if none given
+        if cmap is None:
+            cmap = {'p_l': PyDARNColormaps.PYDARN_PLASMA,
+                    'v': PyDARNColormaps.PYDARN_VELOCITY,
+                    'w_l': PyDARNColormaps.PYDARN_VIRIDIS,
+                    'elv': PyDARNColormaps.PYDARN_INFERNO}
+            cmap = cmap[data_parameter]
+
+        # Set background to transparent - avoids carry over
+        # does not interfere with the fov color if chosen
+        cmap.set_bad(alpha=0.0)
+
+        # Setting zmin and zmax
+        defaultzminmax = {'p_l': [0, 50], 'v': [-200, 200],
+                          'w_l': [0, 250], 'elv': [0, 50]}
+        if zmin is None:
+            zmin = defaultzminmax[data_parameter][0]
+        if zmax is None:
+            zmax = defaultzminmax[data_parameter][1]
+        norm = colors.Normalize
+        norm = norm(zmin, zmax)
+
+        kwargs['hemisphere'] = SuperDARNRadars.radars[stid].hemisphere
+        ax, ccrs = projs(date=data_datetime, ax=ax, **kwargs)
+
+        if ccrs is None:
+            transform = ax.transData
+        else:
+            transform = ccrs.PlateCarree()
+
+        # Plot the data in the scan
+        ax.pcolormesh(thetas, rs, scan,
+                      norm=norm, cmap=cmap, transform=transform,
+                      zorder=2)
+        # Plot the groundscatter as grey fill
+        if data_groundscatter != []:
+            ax.pcolormesh(thetas, rs,
+                          np.ma.masked_array(grndsct,
+                                             ~grndsct.astype(bool)),
+                          norm=norm, cmap='Greys',
+                          transform=transform, zorder=3)
+        if ccrs is None:
+            azm = np.linspace(0, 2 * np.pi, 100)
+            r, th = np.meshgrid(rs, azm)
+            ax.plot(azm, r, color='k', ls='none')
+            ax.grid(True)
+
+        if boundary:
+            Fan.plot_fov(stid=stid, date=data_datetime, ax=ax,
+                         ccrs=ccrs, coords=coords, projs=projs, rsep=rsep,
+                         frang=frang, ranges=[0, len(data_array)], **kwargs)
+
+        # Create color bar if True
+        if colorbar is True:
+            mappable = cm.ScalarMappable(norm=norm, cmap=cmap)
+            locator = ticker.MaxNLocator(symmetric=True, min_n_ticks=3,
+                                         integer=True, nbins='auto')
+            ticks = locator.tick_values(vmin=zmin, vmax=zmax)
+
+            if zmin == 0:
+                extend = 'max'
+            else:
+                extend = 'both'
+
+            if cax is None:
+                cax = ax.inset_axes([1.04, 0.0, 0.05, 1.0])
+            cb = ax.figure.colorbar(mappable, ax=ax, cax=cax, extend=extend,
+                                    ticks=ticks)
+
+            if colorbar_label != '':
+                cb.set_label(colorbar_label)
+        else:
+            cb = None
+
+        # Determine embargo status
+        #cls.__determine_embargo(time2datetime(dmap_data[plot_beams[-1][-1]])
+        return {'ax': ax,
+                'ccrs': ccrs,
+                'cm': cmap,
+                'cb': cb,
+                'fig': plt.gcf(),
+                'data': {'beam_corners_lats': beam_corners_lats,
+                         'beam_corners_lons': beam_corners_lons,
+                         'scan_data': scan,
+                         'ground_scatter': grndsct}
+                }
 
     @staticmethod
     def plot_fov(stid: int, date: dt.datetime,

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -491,7 +491,7 @@ class Fan:
 
         Parameters
         -----------
-            data_array: List[ranges, gates]
+            data_array: List[ranges, beams]
                 Array of data, must be in shape of standard fan plot
             data_datetime: datetime object
                 Time at which data is taken or wanted to be plotted
@@ -554,8 +554,17 @@ class Fan:
         --------
             plot_fov
         """
+        # Checks on data before plotting
+        stid_beams = SuperDARNRadars.radars[stid].hardware_info.beams
+        if stid_beams != len(data_array[0]):
+            warnings.warn('The data you have inputted to the method does not '
+                          'match the expected number of beams for this radar. '
+                          'The data will still plot, but the position of the '
+                          'extra beams may not be as expected.')
+
         beam_corners_lats, beam_corners_lons =\
             coords(stid=stid, rsep=rsep, frang=frang,
+                   beams=len(data_array[0]),
                    gates=[0, len(data_array)], date=data_datetime,
                    **kwargs)
 

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -507,6 +507,12 @@ class Fan:
                 with MLT/latitude labels
             data_groundscatter: list[beams, ranges]
                 Boolean array of same size which denotes groundscatter
+            rsep: int
+                Separation between range gates, in kilometers.
+                Default: 45
+            frang: int
+                Kilometers to first range.
+                Default: 180
             stid: int
                 StationID of the radar of interest
             data_parameter: str

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -567,8 +567,8 @@ class Fan:
         else:
             thetas = beam_corners_lons
 
-        scan = data_array
-        grndsct = data_groundscatter
+        scan = np.ma.array(data_array, mask=np.isnan(data_array))
+        grndsct = np.array(data_groundscatter)
 
         # Colour table and max value selection depending on parameter plotted
         # Load defaults if none given


### PR DESCRIPTION
# Scope 

This pull request hopes to give an option to anyone who needs more flexibility to the fan plots. You can essentially plot whatever data you want at any time for any radar, given you can make the data be in the right format. 

You will need to make a 2D list of data that matches the FOV of the target radar, where no data is given as NaN values, data is given as a float, and an array of 0,1 in the same dimensions will act as groundscatter with the dimensions [ranges, beams].

**issue:** to close #387 

## Approval

**Number of approvals:** 2

## Test

**matplotlib version**: 3.9.1
**Note testers: please indicate what version of matplotlib you are using**

Note: If you come across an error that traces back to numpy or pydarnio, please downgrade numpy, it is out of scope of pyDARN to fix this. 
There will also likely be a merge conflict, so be aware. 

```python
import matplotlib.pyplot as plt
import pydarn
import datetime as dt
import numpy as np

# ==========================================================================
# Test completely made up data for SAS
# Made up data in format [75, 16]
data_array = [(np.ones(16) * (x - 36) * 10).tolist() for x in range(75)]
# Add some areas with no data
for i in range(65,70):
    data_array[i] = (np.empty(16) * np.nan).tolist()

# Made up groundscatter boolean array
data_groundscatter = [(np.zeros(16)).tolist() for x in range(75)]
for i in range(30,40):
    data_groundscatter[i] = (np.ones(16)).tolist()

stid = 5
data_datetime = dt.datetime(2024,1,1,0,0)

pydarn.Fan.plot_fan_input(data_array=data_array,
                          data_datetime=data_datetime,
                          stid=stid,
                          data_groundscatter = data_groundscatter,
                          data_parameter='v',
                          zmin=-400,zmax=400, lowlat=50, coastline=True)
plt.show()

# ==========================================================================
# Test completely made up data with bigger fan size for BKS
# Made up data in format [110, 24]
data_array = [(np.ones(24) * (x - 36) * 10).tolist() for x in range(110)]
# Add some areas with no data
for i in range(65,70):
    data_array[i] = (np.empty(24) * np.nan).tolist()

# Made up groundscatter boolean array
data_groundscatter = [(np.zeros(24)).tolist() for x in range(110)]
for i in range(30,40):
    data_groundscatter[i] = (np.ones(24)).tolist()

stid = 33
data_datetime = dt.datetime(2024,1,1,0,0)

pydarn.Fan.plot_fan_input(data_array=data_array,
                          data_datetime=data_datetime,
                          stid=stid,
                          data_groundscatter = data_groundscatter,
                          data_parameter='v',
                          zmin=-400,zmax=400, lowlat=30, coastline=True)
plt.show()

# ==========================================================================
# Test completely made up data with non-standard fan size?
# Made up data in format [110, 24]
data_array = [(np.ones(24) * (x - 36) * 10).tolist() for x in range(110)]
# Add some areas with no data
for i in range(65,70):
    data_array[i] = (np.empty(24) * np.nan).tolist()

# Made up groundscatter boolean array
data_groundscatter = [(np.zeros(24)).tolist() for x in range(110)]
for i in range(30,40):
    data_groundscatter[i] = (np.ones(24)).tolist()

stid = 5
data_datetime = dt.datetime(2024,1,1,0,0)

pydarn.Fan.plot_fan_input(data_array=data_array,
                          data_datetime=data_datetime,
                          stid=stid,
                          data_groundscatter = data_groundscatter,
                          data_parameter='v',
                          zmin=-400,zmax=400, lowlat=50, coastline=True)
plt.show()

# ==========================================================================
# Test with camping beam real data from FHE
file = "/Users/carley/Documents/data/20231122.0402.00.fhe.fitacf"
SDarn_read = pydarn.SuperDARNRead(file)
fitacf_data = SDarn_read.read_fitacf()

# find the data you want to plot int eh file using a dateitme
scan_time = dt.datetime(2023,11,22,4,16)
matching_records = pydarn.find_records_by_datetime(fitacf_data, scan_time,
                                                   dt.timedelta(seconds=120))

# Make empty data array to correct size
data_array = [(np.empty(22) * np.nan).tolist() for x in range(110)]
data_groundscatter = [(np.zeros(22)).tolist() for x in range(110)]

# Do fun stuff to the camped beam (THIS IS JUST AN EXAMPLE OF WHAT CAN BE DONE
# DONT @ ME FOR THE SCIENTIFIC PURPOSE OF DOING THIS SPECIFICALLY TO THE DATA)
camped_beam = 10
camped_count = 0

for i in range(len(matching_records)):
    for g, gate in enumerate(matching_records[i]['slist']):
        if matching_records[i]['bmnum'] != camped_beam:
            data_array[gate][matching_records[i]['bmnum']] =\
                matching_records[i]['v'][g]
            data_groundscatter[gate][matching_records[i]['bmnum']] =\
                matching_records[i]['gflg'][g]
        else:
            if matching_records[i]['gflg'][g] == 0:
                if np.isnan(data_array[gate][matching_records[i]['bmnum']]):
                    data_array[gate][matching_records[i]['bmnum']] =\
                        matching_records[i]['v'][g]
                else:
                    data_array[gate][matching_records[i]['bmnum']] =\
                        data_array[gate][matching_records[i]['bmnum']] +\
                        matching_records[i]['v'][g]
    if matching_records[i]['bmnum'] != camped_beam:
        camped_count+=1

for g in range(110):
    data_array[g][camped_beam] = data_array[g][camped_beam] / camped_count
# This is ignoring groundscatter for beam 10, and assuming that it is okay to
# average the data collected over the two minutes, I would probably personally
# choose one of the records to plot rather than averaging all the data in it
# but it's really up to the user how they present and interpret their data
# please don't blame me haha! There's also probably a better way to make this
# data array, I'm just playing with it.

# plot using new input
pydarn.Fan.plot_fan_input(data_array=data_array,
                          data_datetime=scan_time,
                          stid=fitacf_data[0]['stid'],
                          data_groundscatter = data_groundscatter,
                          data_parameter='v',
                          zmin=-600,zmax=600, lowlat=30, coastline=True)
plt.show()

# Traditional plot to compare to, with all records in camped beam overplotted
rtn = pydarn.Fan.plot_fan(fitacf_data, scan_index=scan_time, groundscatter=True,
                          coastline=True, lowlat=40, zmin=-600, zmax=600,
                          tolerance=dt.timedelta(seconds=120))
plt.show()
```


Lots of plots, not much science, mainly for examples!
<img width="755" alt="Screenshot 2024-07-16 at 4 04 08 PM" src="https://github.com/user-attachments/assets/114d7dc9-3f00-4d2f-ac70-3007f740124d">
<img width="738" alt="Screenshot 2024-07-16 at 4 04 26 PM" src="https://github.com/user-attachments/assets/49765534-0b57-4a24-944c-a309b6d563c0">
<img width="739" alt="Screenshot 2024-07-16 at 4 04 38 PM" src="https://github.com/user-attachments/assets/b67ccb10-04e3-43cd-882e-1a0a1434c160">
<img width="730" alt="Screenshot 2024-07-16 at 4 04 55 PM" src="https://github.com/user-attachments/assets/e8f88ede-80ef-42be-af9c-92d3ae3d168b">
<img width="761" alt="Screenshot 2024-07-16 at 4 05 09 PM" src="https://github.com/user-attachments/assets/694718ca-d9ec-41a8-8935-687e67319abd">



