### PR TITLE
DEP: Matplotlib plot_date deprecation

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -778,9 +778,8 @@ class RTP:
             my = np.ma.array(y)
             my = np.ma.masked_where(np.isnan(my), my)
 
-            lines = ax.plot_date(x, my, fmt=color, tz=None, xdate=True,
-                                 ydate=False, linestyle=linestyle,
-                                 linewidth=linewidth)
+            lines = ax.plot(x, my, color=color, linestyle=linestyle,
+                            linewidth=linewidth)
 
             if round_start:
                 major_locator, _ = plt.xticks()


### PR DESCRIPTION
# Scope 

This PR replaces the plot_date function in time series plots with the recommended plot function as plot_date is just a wrapper with a formatting input for dates. We don't use timezones so there should be no issues there. 

https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.plot_date.html

**issue:** to close #393 

## Approval

**Number of approvals:** 1

## Test

**matplotlib version**:  3.7.0 - 3.9.1
**Note testers: please indicate what version of matplotlib you are using**
Testers please test with a few matplotlib versions. 
You can plot any time_series or summary plots to check - you should see no difference between develop and this branch except there is no deprecation notice for matplotlib 3.9+.

```python
a = pydarn.RTP.plot_time_series(fitacf_data, beam_num=5)
plt.show()
a = pydarn.RTP.plot_summary(fitacf_data, beam_num=5)
plt.show()
```
