### PR TITLE
EHN: Flexibility on Plotting Summary Plot Variables

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -1064,9 +1064,26 @@ class RTP:
         axes = []
 
         # Check integrity of vector_parameters before committing to plotting
-        allowed_parameters = ['elv', 'v', 'w_l', 'p_l']
         if not isinstance(vector_parameters, list):
-            vector_parameters = [vector_parameters]
+            raise Exception('The summary plot needs a formatted list of vector '
+                            'parameters to plot. E.G. ["v", "p_l"]. '
+                            'Summary plots allow plotting of the following '
+                            'vector parameters: v (velocity), '
+                            'p_l (Signal to noise ratio), '
+                            'w_l (spectral width), '
+                            'elv (elevation).')
+        # Test for elevation data being removed
+        if not vector_parameters or len(vector_parameters) == 0:
+            raise Exception('The summary plot needs a list of vector '
+                            'parameters to plot. The file you have chosen to '
+                            'plot may not have elevation data. '
+                            'Summary plots allow plotting of the following '
+                            'vector parameters: v (velocity), '
+                            'p_l (Signal to noise ratio), '
+                            'w_l (spectral width), '
+                            'elv (elevation).')
+        # Test for non standard parameters
+        allowed_parameters = ['elv', 'v', 'w_l', 'p_l']
         test_list = [i for i in vector_parameters if i not in allowed_parameters]
         if len(test_list) > 0 :
             raise Exception('Summary plots allow plotting of the following '
@@ -1089,14 +1106,27 @@ class RTP:
                   'v': 'Velocity\n ($m\ s^{-1}$)',
                   'w_l': 'Spectral Width\n ($m\ s^{-1}$)',
                   'elv': 'Elevation\n ($\degree$)'}
+
+
+        # TODO: We need a cleaner solution to this and still allow user input
+        # for figure size. For now it 'works'. Thanks to P. Pitzer for current
+        # solution.
+        start_pos = [0,0,0, 0.60, 0.75, 0.80, 0.84, 0.87, 0.90, 0.92]
         for i in range(num_plots):
             # time-series plots
             # position: [left, bottom, width, height]
             if i < 3:
-                axes.append(fig.add_axes([0.1, 0.88 - (i*0.08), 0.76, 0.06]))
+                axes.append(fig.add_axes([0.1,
+                                          (start_pos[num_plots]) -
+                                          (i / num_plots * .5),
+                                          0.76,
+                                          0.06 * (7 / num_plots)]))
             # range-time plots
             else:
-                axes.append(fig.add_axes([0.1, 1.04 - (i*0.16), 0.95, 0.14]))
+                axes.append(fig.add_axes([0.1,
+                                          1.04 - (i / num_plots * 1.1),
+                                          0.95,
+                                          0.14 * (7 / num_plots)]))
 
         for i in range(num_plots):
             # plot time-series

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -958,6 +958,10 @@ class RTP:
         latlon: str
             set which coordinate you want to plot with
             default: None
+        vector_parameters: list 
+            Required parameters for plotting in the summary plot
+            Must be a subset of the default list below
+            default:[('p_l'), ('v'), ('w_l'), ('elv')]
         kwargs:
             reflection_height for ground_scatter_mapped method
             background
@@ -1058,6 +1062,18 @@ class RTP:
             num_plots = len(scalar_parameters) + len(vector_parameters) - 1
             vector_parameters.remove('elv')
         axes = []
+
+        # Check integrity of vector_parameters before committing to plotting
+        allowed_parameters = ['elv', 'v', 'w_l', 'p_l']
+        if not isinstance(vector_parameters, list):
+            vector_parameters = [vector_parameters]
+        test_list = [i for i in vector_parameters if i not in allowed_parameters]
+        if len(test_list) > 0 :
+            raise Exception('Summary plots allow plotting of the following '
+                            'vector parameters only: v (velocity), '
+                            'p_l (Signal to noise ratio), '
+                            'w_l (spectral width), '
+                            'elv (elevation).')
 
         # List of parameters plotted in the summary plot, tuples are used
         # for shared plot parameters like noise.search and noise.sky


### PR DESCRIPTION
# Scope 

Following on from #399 
Integrated code into the summary plot method to allow user to print a subset of the allowed vector parameters (user requested)

## Approval

**Number of approvals:** 1

## Test

**matplotlib version**: 3.9.1
**Note testers: please indicate what version of matplotlib you are using**

```python
import matplotlib.pyplot as plt 
import pydarn
import datetime as dt


# Normal data and data that doesnt contain elv anyway so automatically doesn't plot that
files = ["/Users/carley/Documents/data/20211102.0000.00.rkn.a.fitacf",
        "/Users/carley/Documents/data/20231122.0402.00.fhe.fitacf"]

for file in files:
    SDarn_read = pydarn.SuperDARNRead(file)
    fitacf_data = SDarn_read.read_fitacf()
    
    # Single non list value
    a = pydarn.RTP.plot_summary(fitacf_data, beam_num=5, vector_parameters='v')
    plt.show()
    
    # This example should raise an error
    #a = pydarn.RTP.plot_summary(fitacf_data, beam_num=5, vector_parameters=['elv', 'vel'])
    #plt.show()
    
    # Elevation first
    a = pydarn.RTP.plot_summary(fitacf_data, beam_num=5, vector_parameters=['elv', 'v'])
    plt.show()
    
    # Only v in list
    a = pydarn.RTP.plot_summary(fitacf_data, beam_num=5, vector_parameters=['v'])
    plt.show()
    
    # Random other example
    a = pydarn.RTP.plot_summary(fitacf_data, beam_num=5, vector_parameters=['v', 'elv', 'p_l'])
    plt.show()
    
    # Default
    a = pydarn.RTP.plot_summary(fitacf_data, beam_num=5)
    plt.show()
```

Should all plot a summary plot with the given variables in the order given.
I used RKN data for normal data and FHE data to test here to show what would happen if there isn't elevation data anyway (it will just not pot elevation if you ask for it, how it works now).