### PR TITLE
Add `marker` and `markersize` keywords to plot_radar_position()

### DIFF
--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -26,6 +26,7 @@
 # 2023-08-16: CJM - Corrected for winding order in geo plots
 # 2023-06-28: CJM - Refactored return values
 # 2023-10-14: CJM - Add embargoed data method
+# 2024-10-09: DDB - Control marker and its size in plot_radar_position()
 #
 # Disclaimer:
 # pyDARN is under the LGPL v3 license found in the root directory LICENSE.md
@@ -953,7 +954,10 @@ class Fan:
                             transform: object = None,
                             coords: Coords = Coords.AACGM_MLT,
                             projs: Projs = Projs.POLAR,
-                            line_color: str = 'black', **kwargs):
+                            line_color: str = 'black',
+                            marker: str = '.',
+                            markersize: int = 5,
+                            **kwargs):
         """
         plots only a dot at the position of a given radar station ID (stid)
 
@@ -964,14 +968,21 @@ class Fan:
             ax: matplotlib.axes.Axes
                 Pre-defined axis object to plot on.
             date: datetime.datetime
-                sets the datetime used to find the coordinates of the
+                Sets the datetime used to find the coordinates of the
                 FOV
             transform:
             coords: Coords object
             projs: Projs object
             line_color: str
-                color of the dot
-                default: black
+                Color of the dot
+                Default: black
+            marker: str
+                Controls the symbol plotted.
+                Default: "."
+                See https://matplotlib.org/stable/api/markers_api.html#module-matplotlib.markers for options
+            markersize: int
+                Controls the size of the symbol plotted, "s" passed to ax.scatter().
+                Default: 5
 
         Returns
         -------
@@ -992,7 +1003,7 @@ class Fan:
         if projs == Projs.POLAR:
             lon = np.radians(lon)
         # Plot a dot at the radar site
-        ax.scatter(lon, lat, c=line_color, s=5, transform=transform)
+        ax.scatter(lon, lat, c=line_color, s=markersize, transform=transform, marker=marker)
         return
 
     @staticmethod


### PR DESCRIPTION
# Scope 

This PR simply adds `marker` and `markersize` keywords to `plot_radar_position()` so that the markers themselves can be controlled. Right now that is just control of their size and shape. Shapes are based on those available to `ax.scatter()` ([see matplotlib docs](https://matplotlib.org/stable/api/markers_api.html#module-matplotlib.markers))

## Approval

**Number of approvals:** *1*

## Test

```python
import pydarn
import cartopy.crs as ccrs
import cartopy.feature as cfeature
import datetime as dt

ax, _ = pydarn.plotting.projections.axis_geographic(dt.datetime(2024, 10, 9), cartopy_scale='10m', plot_center=[-100.2, 70], plot_extent=[40, 40], grid_lines=False)

land_10m = cfeature.NaturalEarthFeature('physical', 'land', '50m', edgecolor='black', facecolor='ivory', linewidth=0.2)
ax.add_feature(land_10m, zorder=0)


# Plot red stars at all northern hemisphere radars except those that are decommissioned (see https://superdarn.ca/radar-info)
for stid in pydarn.SuperDARNRadars.radars.keys():
    if pydarn.SuperDARNRadars.radars[stid].hemisphere == pydarn.Hemisphere.North:
        if stid not in [2, 8, 9, 10]:
            pydarn.Fan.plot_radar_position(stid, ax=ax, date=dt.datetime(2024, 10, 9), coords=pydarn.Coords.GEOGRAPHIC, projs=pydarn.Projs.GEO, transform=ccrs.PlateCarree(), marker='*', markersize=10, line_color='red')
```

Output:
<img width="427" alt="Screenshot 2024-10-09 at 12 42 55" src="https://github.com/user-attachments/assets/35278aee-330a-4276-960b-b4b054990bf1">


