### PR TITLE
Fixed improper invocation of np.zeros()

### DIFF
--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -324,7 +324,7 @@ class RTP:
                     x.append(x[-1] + timedelta(0, 120))
                     i = len(x) - 1  # offset since we start at 0 not 1
                     if i > 0:
-                        z = np.insert(z, len(z), np.zeros(1, y_max) * np.nan,
+                        z = np.insert(z, len(z), np.zeros([1, y_max]) * np.nan,
                                       axis=0)
             # Get data for the provided beam number
             if (beam_num == 'all' or dmap_record['bmnum'] == beam_num) and\
@@ -341,7 +341,7 @@ class RTP:
 
                     # insert a new column into the z_data
                     if i > 0:
-                        z = np.insert(z, len(z), np.zeros(1, y_max) * np.nan,
+                        z = np.insert(z, len(z), np.zeros([1, y_max]) * np.nan,
                                       axis=0)
                     try:
                         if len(dmap_record[parameter]) == dmap_record['nrang']:
@@ -1709,7 +1709,7 @@ class RTP:
                     x.append(x[-1] + timedelta(0, 120))
                     i = len(x) - 1  # offset since we start at 0 not 1
                     if i > 0:
-                        z = np.insert(z, len(z), np.zeros(1, y_max) * np.nan,
+                        z = np.insert(z, len(z), np.zeros([1, y_max]) * np.nan,
                                       axis=0)
             # Get data for the provided beam number
             if (beam_num == 'all' or dmap_record['bmnum'] == beam_num) and\
@@ -1726,7 +1726,7 @@ class RTP:
 
                     # insert a new column into the z_data
                     if i > 0:
-                        z = np.insert(z, len(z), np.zeros(1, y_max) * np.nan,
+                        z = np.insert(z, len(z), np.zeros([1, y_max]) * np.nan,
                                       axis=0)
                     try:
                         if len(dmap_record[parameter]) == dmap_record['nrang']:


### PR DESCRIPTION
# Scope 

Fixes calls to `np.zeros()` that did not pass shape correctly.

**issue:** #404 

## Approval

**Number of approvals:** 1

## Test

**matplotlib version**: 3.9.2
**Note testers: please indicate what version of matplotlib you are using**

Use `pydarn.RTP.plot_range_time()` and `pydarn.RTP.plot_coord_time()` with data that has a gap longer than 2 minutes in the middle.
