### PR TITLE
Stid enum

### DIFF
--- a/docs/user/axis.md
+++ b/docs/user/axis.md
@@ -26,7 +26,7 @@ import pydarn
 import datetime as dt
 import matplotlib.pyplot as plt
 
-pydarn.Fan.plot_fov(stid=65, date=dt.datetime(2024,7,23,0,0),
+pydarn.Fan.plot_fov(stid=pydarn.RadarID.RKN, date=dt.datetime(2024,7,23,0,0),
                     radar_label=True, fov_color='green',
                     line_color='green', alpha=0.8, lowlat=60, coastline=True,
                     projs=pydarn.Projs.POLAR, coords=pydarn.Coords.AACGM_MLT)
@@ -60,7 +60,7 @@ import pydarn
 import datetime as dt
 import matplotlib.pyplot as plt
 
-pydarn.Fan.plot_fov(stid=65, date=dt.datetime(2024,7,23,0,0),
+pydarn.Fan.plot_fov(stid=pydarn.RadarID.RKN, date=dt.datetime(2024,7,23,0,0),
                     radar_label=True, fov_color='green',
                     line_color='green', alpha=0.8, plot_extent=[80,50],
                     coastline=True, projs=pydarn.Projs.GEO,
@@ -96,7 +96,7 @@ import pydarn
 import datetime as dt
 import matplotlib.pyplot as plt
 
-pydarn.Fan.plot_fov(stid=65, date=dt.datetime(2024,7,23,0,0),
+pydarn.Fan.plot_fov(stid=pydarn.RadarID.RKN, date=dt.datetime(2024,7,23,0,0),
                     radar_label=True, fov_color='green',
                     line_color='green', alpha=0.8, plot_extent=[80,50],
                     coastline=True, projs=pydarn.Projs.MAG,
@@ -132,7 +132,7 @@ ax1.set_xticks([0, np.radians(45), np.radians(90), np.radians(135),
                        np.radians(315)])
 ax1.set_xticklabels(['00', '', '06', '', '12', '', '18', ''])
 ax1.set_theta_zero_location("S")
-pydarn.Fan.plot_fov(stid=65, date=date, ax=ax1)
+pydarn.Fan.plot_fov(stid=pydarn.RadarID.RKN, date=date, ax=ax1)
 
 # Geo plot
 deg_from_midnight = (date.hour + date.minute / 60) / 24 * 360
@@ -144,7 +144,7 @@ ax2 = fig.add_subplot(122, projection=proj, aspect='auto')
 ax2.gridlines(draw_labels=True)
 extent = min(45e5,(abs(proj.transform_point(noon, 30, ccrs.PlateCarree())[1])))
 ax2.set_extent(extents=(-extent, extent, -extent, extent), crs=proj)
-pydarn.Fan.plot_fov(stid=65, date=date, ax=ax2, ccrs=ccrs, coords=pydarn.Coords.GEOGRAPHIC, projs=pydarn.Projs.GEO)
+pydarn.Fan.plot_fov(stid=pydarn.RadarID.RKN, date=date, ax=ax2, ccrs=ccrs, coords=pydarn.Coords.GEOGRAPHIC, projs=pydarn.Projs.GEO)
 plt.tight_layout()
 plt.show()
 ```

--- a/docs/user/coordinates.md
+++ b/docs/user/coordinates.md
@@ -104,7 +104,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # North Winter
-pydarn.Fan.plot_fov(66, dt.datetime(2023, 12, 21, 0, 0),
+pydarn.Fan.plot_fov(pydarn.RadarID.CLY, dt.datetime(2023, 12, 21, 0, 0),
     lowlat= 5, boundary=True, line_color='red', coastline=True)
 
 # Test to plot terminator if ever required - plot line not fill!

--- a/docs/user/fan.md
+++ b/docs/user/fan.md
@@ -227,12 +227,11 @@ data_groundscatter = [(np.zeros(16)).tolist() for x in range(75)]
 for i in range(30,40):
     data_groundscatter[i] = (np.ones(16)).tolist()
 
-stid = 5
 data_datetime = dt.datetime(2024,1,1,0,0)
 
 pydarn.Fan.plot_fan_input(data_array=data_array,
                           data_datetime=data_datetime,
-                          stid=stid,
+                          stid=pydarn.RadarID.SAS,
                           data_groundscatter = data_groundscatter,
                           data_parameter='v',
                           zmin=-400,zmax=400, lowlat=50, coastline=True)

--- a/docs/user/fov.md
+++ b/docs/user/fov.md
@@ -24,7 +24,7 @@ import pydarn
 from datetime import datetime
 import matplotlib.pyplot as plt 
 
-pydarn.Fan.plot_fov(66, datetime(2015, 3, 8, 15, 0), radar_label=True)
+pydarn.Fan.plot_fov(pydarn.RadarID.CLY, datetime(2015, 3, 8, 15, 0), radar_label=True)
 plt.show()
 ```
 
@@ -37,8 +37,8 @@ A `datetime` object of the date is required to convert to `Coords.AACGM_MLT` (de
 Here is a list of all the current options than can be used with `plot_fov`
 
 | Option                  | Action                                                                                                  |
-| ----------------------- | ------------------------------------------------------------------------------------------------------- |
-| stid=(int)              | Station id of the radar. Can be found using [SuperDARNRadars](hardware.md)                              |
+|-------------------------|---------------------------------------------------------------------------------------------------------|
+| stid=pydarn.RadarID     | Station id of the radar.                                                                                |
 | date=(datetime)         | `datetime` object to determine the position the radar fov AACGM or AACGM MLT coordinates                |
 | ranges=(list)           | Two element list giving the lower and upper ranges to plot, grabs ranges from hardware file (default [] |
 | ax=(Axes Object)        | Matplotlib axes object than can be used for cartopy additions                                           |
@@ -70,22 +70,28 @@ To plot based on hemisphere or selection of radars, here is an example plotting 
 ```python
 import pydarn
 from datetime import datetime
-import matplotlib.pyplot as plt 
+import matplotlib.pyplot as plt
 
-fov_rtn={}
+fov_rtn = {}
 fov_rtn['ax'] = None
-for stid in pydarn.SuperDARNRadars.radars.keys():
+for stid in pydarn.RadarID:
     if pydarn.SuperDARNRadars.radars[stid].hemisphere == pydarn.Hemisphere.North:
-        if stid != 2:
-            if stid in [66, 65, 6, 65, 5]: 
-                fov_rtn = pydarn.Fan.plot_fov(stid, datetime(2021, 2, 5, 12, 5), 
-                                    radar_label=True, fov_color='green',
-                                    line_color='green', alpha=0.8, ax=fov_rtn['ax'])
-
-            fov_rtn = pydarn.Fan.plot_fov(stid, datetime(2021, 2, 5, 12, 5), 
-                                radar_label=True, fov_color='blue',
-                                line_color='blue', alpha=0.2, lowlat=10, 
-                                ax=fov_rtn['ax'])
+        if stid != pydarn.RadarID.SCH:
+            if stid in [
+                pydarn.RadarID.SAS,
+                pydarn.RadarID.PGR,
+                pydarn.RadarID.CLY,
+                pydarn.RadarID.RKN,
+                pydarn.RadarID.INV
+            ]:
+                fov_rtn = pydarn.Fan.plot_fov(stid, datetime(2021, 2, 5, 12, 5),
+                                              radar_label=True, fov_color='green',
+                                              line_color='green', alpha=0.8, ax=fov_rtn['ax'])
+            else:
+                fov_rtn = pydarn.Fan.plot_fov(stid, datetime(2021, 2, 5, 12, 5),
+                                              radar_label=True, fov_color='blue',
+                                              line_color='blue', alpha=0.2, lowlat=10,
+                                              ax=fov_rtn['ax'])
 
 plt.show()
 ```
@@ -97,16 +103,16 @@ This example will plot all radars in the southern hemisphere FOV in red:
 ```python
 import pydarn
 from datetime import datetime
-import matplotlib.pyplot as plt 
+import matplotlib.pyplot as plt
 
-fov_rtn={}
+fov_rtn = {}
 fov_rtn['ax'] = None
-for stid in pydarn.SuperDARNRadars.radars.keys():
+for stid in pydarn.RadarID:
     if pydarn.SuperDARNRadars.radars[stid].hemisphere == pydarn.Hemisphere.South:
-        if stid != 2:
+        if stid != pydarn.RadarID.SCH:
             fov_rtn = pydarn.Fan.plot_fov(stid, datetime(2021, 2, 5, 12, 5),
-                                radar_label=True, fov_color='red',
-                                line_color='red', alpha=0.2, ax=fov_rtn['ax'])
+                                          radar_label=True, fov_color='red',
+                                          line_color='red', alpha=0.2, ax=fov_rtn['ax'])
 plt.show()
 ```
 
@@ -120,7 +126,7 @@ import pydarn
 from datetime import datetime
 import matplotlib.pyplot as plt 
 
-pydarn.Fan.plot_fov(stid=65, date=datetime(2022, 1, 8, 14, 5),
+pydarn.Fan.plot_fov(stid=pydarn.RadarID.RKN, date=datetime(2022, 1, 8, 14, 5),
                     fov_color='red', coords=pydarn.Coords.GEOGRAPHIC,
                     projs=pydarn.Projs.GEO, coastline=True)
 plt.show()
@@ -138,27 +144,27 @@ import pydarn
 from datetime import datetime
 import matplotlib.pyplot as plt 
 
-fov_rtn = pydarn.Fan.plot_fov(66, datetime(2021, 6, 21, 6, 0),
+fov_rtn = pydarn.Fan.plot_fov(pydarn.RadarID.CLY, datetime(2021, 6, 21, 6, 0),
                               lowlat= 50, boundary=True, radar_label=True,
                               line_color='red', grid = True,
                               coords=pydarn.Coords.GEOGRAPHIC,
                               projs=pydarn.Projs.GEO, coastline=True)
-pydarn.Fan.plot_fov(5, datetime(2021, 2, 5, 12, 5), radar_label=True,
+pydarn.Fan.plot_fov(pydarn.RadarID.SAS, datetime(2021, 2, 5, 12, 5), radar_label=True,
                     ax=fov_rtn['ax'], ccrs=fov_rtn['ccrs'], boundary=True,
                     line_color='blue', grid = True,
                     coords=pydarn.Coords.GEOGRAPHIC,
                     projs=pydarn.Projs.GEO)
-pydarn.Fan.plot_fov(64, datetime(2021, 2, 5, 12, 5), radar_label=True,
+pydarn.Fan.plot_fov(pydarn.RadarID.INV, datetime(2021, 2, 5, 12, 5), radar_label=True,
                     ax=fov_rtn['ax'], ccrs=fov_rtn['ccrs'],
                     boundary=True, line_color='green',
                     grid = True, coords=pydarn.Coords.GEOGRAPHIC,
                     projs=pydarn.Projs.GEO)
-pydarn.Fan.plot_fov(65, datetime(2021, 2, 5, 12, 5), radar_label=True,
+pydarn.Fan.plot_fov(pydarn.RadarID.RKN, datetime(2021, 2, 5, 12, 5), radar_label=True,
                     ax=fov_rtn['ax'], ccrs=fov_rtn['ccrs'],
                     boundary=True, line_color='orange',
                     grid = True, coords=pydarn.Coords.GEOGRAPHIC,
                     projs=pydarn.Projs.GEO)
-pydarn.Fan.plot_fov(6, datetime(2021, 2, 5, 12, 5), radar_label=True,
+pydarn.Fan.plot_fov(pydarn.RadarID.PGR, datetime(2021, 2, 5, 12, 5), radar_label=True,
                     ax=fov_rtn['ax'], ccrs=fov_rtn['ccrs'],
                     boundary=True, grid = True,
                     coords=pydarn.Coords.GEOGRAPHIC, projs=pydarn.Projs.GEO)
@@ -175,7 +181,7 @@ import pydarn
 from datetime import datetime
 import matplotlib.pyplot as plt 
 
-pydarn.Fan.plot_fov(66, datetime(2021, 2, 5, 12, 5), boundary=False,
+pydarn.Fan.plot_fov(pydarn.RadarID.CLY, datetime(2021, 2, 5, 12, 5), boundary=False,
                     radar_label=True)
 plt.show()
 ```

--- a/docs/user/grid.md
+++ b/docs/user/grid.md
@@ -65,7 +65,7 @@ In addition to the gridded line-of-sight velocity, you can choose one of two oth
 Here is a list of all the current options than can be used with `plot_grid`
 
 | Option                         | Action                                                                                |
-| ------------------------------ | ------------------------------------------------------------------------------------- |
+|--------------------------------| ------------------------------------------------------------------------------------- |
 | record=(int)                   | Record number to plot                                                                 |
 | start_time=(datetime.datetime) | The start time of the record to plot                                                  |
 | time_delta=(int)               | How close to the start time to be to the start time of the record                     |
@@ -77,12 +77,12 @@ Here is a list of all the current options than can be used with `plot_grid`
 | colorbar=(bool)                | Set true to plot a colorbar (default: True)                                           |
 | colorbar_label=(string)        | Label for the colour bar (requires colorbar to be true)                               |
 | title=(str)                    | To add a title to the plot                                                            |
-| radar_label=(str)        | To include a dot at radar location and label of 3 letter code |
-| fov_color=(str)           | Fill color of fov                                                         |
-| line_color=(str)      | Fill color of fov lines                                                                          |
+| radar_label=(str)              | To include a dot at radar location and label of 3 letter code |
+| fov_color=(str)                | Fill color of fov                                                         |
+| line_color=(str)               | Fill color of fov lines                                                                          |
 | coastline=(bool)               | Plots outlines of coastlines below grid data      |
-| coords=(Coords)               | [Coordinates](coordinates.md) for the data to be plotted in                                             |
-| projs=(Projs)                 | Projections to plot the data on top of                                                                  |
+| coords=(Coords)                | [Coordinates](coordinates.md) for the data to be plotted in                                             |
+| projs=(Projs)                  | Projections to plot the data on top of                                                                  |
 
 As an example, the following code plots multiple radar Grid plot:
 ```python

--- a/docs/user/hardware.md
+++ b/docs/user/hardware.md
@@ -80,8 +80,8 @@ This class contains a dictionary of all currently accepted SuperDARN radars (inc
 ``` python
 import pydarn
 
-# Access Prince Georges Radar information
-radar_info = pydarn.SuperDARNRadars.radars[6]
+# Access Prince George Radar information
+radar_info = pydarn.SuperDARNRadars.radars[pydarn.RadarID.PGR]
 print(radar_info)
 ```
 
@@ -101,8 +101,8 @@ Example code:
 ```python
 import pydarn
 
-# Geographic coordinates for Clyde River (STID: 66) FOV
-geo_lats, geo_lons=pydarn.Coords.GEOGRAPHIC(66)
+# Geographic coordinates for Clyde River FOV
+geo_lats, geo_lons=pydarn.Coords.GEOGRAPHIC(pydarn.RadarID.CLY)
 ```
 
 You also have the option to set the `coords` keyword to `aacgm`. In this case, [Altitude adjusted corrected geomagnetic](http://superdarn.thayer.dartmouth.edu/aacgm.html) latitude and longitude are returned instead of geographic. Because AACGM requires a date to convert coordinates accurately, a python datetime object is also required to be passed in to `coords` under this circumstance:
@@ -110,8 +110,8 @@ You also have the option to set the `coords` keyword to `aacgm`. In this case, [
 import pydarn
 import datetime as dt
 
-# AACGMv2 coordinates for Dome C (STID: 96), valid for November 26th, 2005
-aacgm_lats, aacgm_lons=pydarn.Coords.AACGM(96, date=dt.datetime(2005, 11, 26))
+# AACGMv2 coordinates for Dome C East, valid for November 26th, 2005
+aacgm_lats, aacgm_lons=pydarn.Coords.AACGM(pydarn.RadarID.DCE, date=dt.datetime(2005, 11, 26))
 ```
 The `Coords` keyword points to the function to convert the radar's Field-of-View to the designed coordinate system. The outputs are two numpy arrays of latitude and longitude coordinates with dimensions (number_of_beams+1 x number_of_gates+1). They correspond to the corners of each range gate.
 

--- a/docs/user/range_time.md
+++ b/docs/user/range_time.md
@@ -201,7 +201,7 @@ plt.show()
 
 Range-time plots also allow users to plot `pwr0` parameters in RAWACF files:
 
-``` python
+```python
 import pydarn
 import matplotlib.pyplot as plt 
 from matplotlib import colors

--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -39,7 +39,7 @@ from .utils.conversions import dmap2dict
 from .utils.plotting import (MapParams, TimeSeriesParams, check_data_type,
     time2datetime, find_record, determine_embargo, add_embargo)
 from .utils.general_utils import GeneralUtils
-from .utils.superdarn_radars import SuperDARNRadars
+from .utils.superdarn_radars import RadarID, SuperDARNRadars
 from .utils.superdarn_cpid import SuperDARNCpids
 from .utils.superdarn_radars import Hemisphere, read_hdw_file, get_hdw_files
 from .utils.scan import find_records_by_datetime, find_records_by_scan

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -52,8 +52,9 @@ from typing import List
 # Third party libraries
 import aacgmv2
 
+import pydarn
 from pydarn import (PyDARNColormaps, partial_record_warning,
-                    time2datetime, plot_exceptions, SuperDARNRadars,
+                    time2datetime, plot_exceptions, SuperDARNRadars, RadarID,
                     calculate_azimuth, Projs, Coords,
                     find_records_by_datetime, find_records_by_scan,
                     determine_embargo, add_embargo)
@@ -491,14 +492,14 @@ class Fan:
 
 
     @staticmethod
-    def plot_fan_input(data_array: list = [], data_datetime: dt.datetime = [], 
-                 ax: object = None, stid: int = None, data_groundscatter: list = [], 
-                 rsep: int = 45, frang: int = 180,
-                 data_parameter: str = 'v', cmap: str = None, zmin: int = None,
-                 zmax: int = None, colorbar: bool = True,
-                 colorbar_label: str = '', cax=None, boundary: bool = True,
-                 projs: Projs = Projs.POLAR,
-                 coords: Coords = Coords.AACGM_MLT, **kwargs):
+    def plot_fan_input(data_array: list = [], data_datetime: dt.datetime = [],
+                       ax: object = None, stid: RadarID = None, data_groundscatter: list = [],
+                       rsep: int = 45, frang: int = 180,
+                       data_parameter: str = 'v', cmap: str = None, zmin: int = None,
+                       zmax: int = None, colorbar: bool = True,
+                       colorbar_label: str = '', cax=None, boundary: bool = True,
+                       projs: Projs = Projs.POLAR,
+                       coords: Coords = Coords.AACGM_MLT, **kwargs):
         """
         Plots a radar's Field Of View (FOV) fan plot for the given data and
         scan number
@@ -522,7 +523,7 @@ class Fan:
             frang: int
                 Kilometers to first range.
                 Default: 180
-            stid: int
+            stid: RadarID
                 StationID of the radar of interest
             data_parameter: str
                 Key name indicating which parameter to plot.
@@ -687,7 +688,7 @@ class Fan:
                 }
 
     @staticmethod
-    def plot_fov(stid: int, date: dt.datetime,
+    def plot_fov(stid: RadarID, date: dt.datetime,
                  ax=None, ccrs=None, ranges: List = None, boundary: bool = True,
                  rsep: int = 45, frang: int = 180,
                  projs: Projs = Projs.POLAR,
@@ -702,7 +703,7 @@ class Fan:
 
         Parameters
         -----------
-            stid: int
+            stid: RadarID
                 Radar station ID
             ax: matplotlib.axes.Axes
                 Pre-defined axis object to pass in.
@@ -907,7 +908,7 @@ class Fan:
                 }
 
     @staticmethod
-    def get_gate_azm(theta: float, r: float, stid: int, coords, date):
+    def get_gate_azm(theta: float, r: float, stid: RadarID, coords, date):
         """
         gets the azimuth of the gate, requires some changes depending on
         coordinates before using calculate_azimuth
@@ -918,7 +919,7 @@ class Fan:
                 longitude
             r: float
                 latitude
-            stid: int
+            stid: RadarID
                 station id of radar
             coords: Enum
                 enumeration of coordinate system
@@ -948,7 +949,7 @@ class Fan:
         return azm
 
     @staticmethod
-    def plot_radar_position(stid: int, ax: axes.Axes,
+    def plot_radar_position(stid: RadarID, ax: axes.Axes,
                             date: dt.datetime,
                             transform: object = None,
                             coords: Coords = Coords.AACGM_MLT,
@@ -959,7 +960,7 @@ class Fan:
 
         Parameters
         -----------
-            stid: int
+            stid: RadarID
                 Radar station ID
             ax: matplotlib.axes.Axes
                 Pre-defined axis object to plot on.
@@ -996,7 +997,7 @@ class Fan:
         return
 
     @staticmethod
-    def plot_radar_label(stid: int, ax: axes.Axes,
+    def plot_radar_label(stid: RadarID, ax: axes.Axes,
                          date: dt.datetime,
                          coords: Coords = Coords.AACGM_MLT,
                          projs: Projs = Projs.POLAR,
@@ -1007,7 +1008,7 @@ class Fan:
 
         Parameters
         -----------
-            stid: int
+            stid: RadarID
                 Radar station ID
             ax: matplotlib.axes.Axes
                 Pre-defined axis object to plot on.

--- a/pydarn/plotting/fan.py
+++ b/pydarn/plotting/fan.py
@@ -52,7 +52,6 @@ from typing import List
 # Third party libraries
 import aacgmv2
 
-import pydarn
 from pydarn import (PyDARNColormaps, partial_record_warning,
                     time2datetime, plot_exceptions, SuperDARNRadars, RadarID,
                     calculate_azimuth, Projs, Coords,

--- a/pydarn/utils/coordinates.py
+++ b/pydarn/utils/coordinates.py
@@ -25,11 +25,13 @@ import enum
 import numpy as np
 
 import aacgmv2
+
+import pydarn
 from pydarn import (geocentric_coordinates, SuperDARNRadars, RangeEstimation,
-                    radar_exceptions, Re)
+                    radar_exceptions, Re, RadarID)
 
 
-def geo_coordinates(stid: int, beams: int = None,
+def geo_coordinates(stid: RadarID, beams: int = None,
                     gates: tuple = None, **kwargs):
     """
     geographic_coordinates calculates the geographic coordinate for a given
@@ -60,7 +62,7 @@ def geo_coordinates(stid: int, beams: int = None,
     return beam_corners_lats[y0inx:], beam_corners_lons[y0inx:]
 
 
-def aacgm_coordinates(stid: int, beams: int = None, gates: tuple = None,
+def aacgm_coordinates(stid: pydarn.RadarID, beams: int = None, gates: tuple = None,
                       date: dt.datetime = dt.datetime.now, **kwargs):
     if gates is None:
         gates = [0, SuperDARNRadars.radars[stid].range_gate_45]
@@ -103,7 +105,7 @@ def convert2MLT(lons: float, date: object, **kwargs):
     return beam_corners_mlts
 
 
-def gate2geographic_location(stid: int, beam: int, height: float = None,
+def gate2geographic_location(stid: pydarn.RadarID, beam: int, height: float = None,
                              elv_angle: float = 0.0, center: bool = False,
                              range_estimation: RangeEstimation =
                              RangeEstimation.SLANT_RANGE, **kwargs):
@@ -113,7 +115,7 @@ def gate2geographic_location(stid: int, beam: int, height: float = None,
 
     parameters
     ----------
-        stid: int
+        stid: pydarn.RadarID
             station id of the radar to use
         beam: int
             beam number (indexing at 0)

--- a/pydarn/utils/superdarn_radars.py
+++ b/pydarn/utils/superdarn_radars.py
@@ -451,6 +451,66 @@ class _Radar(NamedTuple):
     hardware_info: _HdwInfo
 
 
+class RadarID(Enum):
+    """
+    Class used to denote the Station ID (stid) of each radar.
+
+    Attributes
+    ----------
+    Three-letter site code = station ID
+    for each site
+    """
+    # Northern hemisphere radars
+    ADE = 209
+    ADW = 208
+    BKS = 33
+    CVE = 207
+    CVW = 206
+    CLY = 66
+    FHE = 205
+    FHW = 204
+    GBR = 1
+    HAN = 10
+    HJE = 55
+    HJW = 56
+    HOK = 40
+    HKW = 41
+    ICE = 211
+    ICW = 210
+    INV = 64
+    JME = 50
+    KAP = 3
+    KSR = 16
+    KOD = 7
+    LJE = 51
+    LJW = 52
+    LYR = 90
+    PYK = 9
+    PGR = 6
+    RKN = 65
+    SAS = 5
+    SCH = 2
+    SZE = 53
+    SZW = 54
+    STO = 8
+    WAL = 32
+    # Southern hemisphere radars
+    BPK = 24
+    DCE = 96
+    DCN = 97
+    FIR = 21
+    HAL = 4
+    KER = 15
+    MCM = 20
+    SAN = 11
+    SPS = 22
+    SYE = 13
+    SYS = 12
+    TIG = 14
+    UNW = 18
+    ZHO = 19
+
+
 class SuperDARNRadars():
     """
     Class containing a dictionary of Nested Named Tuples with information
@@ -468,152 +528,152 @@ class SuperDARNRadars():
         _Radar : radar object containing radar information
         read_hdw_file : function to read hardware information for a given radar
     """
-    radars = {209: _Radar('Adak Island East',
+    radars = {RadarID.ADE: _Radar('Adak Island East',
                           'University of Alaska Fairbanks', Hemisphere.North,
-                          75, [47, -172], [42, -106], read_hdw_file('ade')),
-              208: _Radar('Adak Island West', 'University of Alaska Fairbanks',
-                          Hemisphere.North, 75, [47, 178], [42, -116],
-                          read_hdw_file('adw')),
-              33: _Radar('Blackstone', 'Virginia Tech', Hemisphere.North,
-                         100, [32, -78], [44, -5], read_hdw_file('bks')),
-              207: _Radar('Christmas Valley East', 'Dartmouth College',
-                          Hemisphere.North, 100, [38, -115], [48, -53],
-                          read_hdw_file('cve')),
-              206: _Radar('Christmas Valley West', 'Dartmouth College',
-                          Hemisphere.North, 100, [38, -125], [48, -63],
-                          read_hdw_file('cvw')),
-              66: _Radar('Clyde River', 'University of Saskatchewan',
-                         Hemisphere.North, 100, [65, -68], [72, 17],
-                         read_hdw_file('cly')),
-              205: _Radar('Fort Hays East', 'Virginia Tech', Hemisphere.North,
-                          100, [34, -94], [45, -25], read_hdw_file('fhe')),
-              204: _Radar('Fort Hays West', 'Virginia Tech', Hemisphere.North,
-                          100, [34, -104], [45, -35], read_hdw_file('fhw')),
-              1: _Radar('Goose Bay', 'Virginia Tech', Hemisphere.North,
-                        100, [48, -60], [54, 23], read_hdw_file('gbr')),
-              10: _Radar('Hankasalmi', 'University of Leicester',
-                         Hemisphere.North, 70, [57, 27], [54, 102],
-                         read_hdw_file('han')),
-              55: _Radar('Hejing East',
+                                  75, [47, -172], [42, -106], read_hdw_file('ade')),
+              RadarID.ADW: _Radar('Adak Island West', 'University of Alaska Fairbanks',
+                                  Hemisphere.North, 75, [47, 178], [42, -116],
+                                  read_hdw_file('adw')),
+              RadarID.BKS: _Radar('Blackstone', 'Virginia Tech', Hemisphere.North,
+                                  100, [32, -78], [44, -5], read_hdw_file('bks')),
+              RadarID.CVE: _Radar('Christmas Valley East', 'Dartmouth College',
+                                  Hemisphere.North, 100, [38, -115], [48, -53],
+                                  read_hdw_file('cve')),
+              RadarID.CVW: _Radar('Christmas Valley West', 'Dartmouth College',
+                                  Hemisphere.North, 100, [38, -125], [48, -63],
+                                  read_hdw_file('cvw')),
+              RadarID.CLY: _Radar('Clyde River', 'University of Saskatchewan',
+                                  Hemisphere.North, 100, [65, -68], [72, 17],
+                                  read_hdw_file('cly')),
+              RadarID.FHE: _Radar('Fort Hays East', 'Virginia Tech', Hemisphere.North,
+                                  100, [34, -94], [45, -25], read_hdw_file('fhe')),
+              RadarID.FHW: _Radar('Fort Hays West', 'Virginia Tech', Hemisphere.North,
+                                  100, [34, -104], [45, -35], read_hdw_file('fhw')),
+              RadarID.GBR: _Radar('Goose Bay', 'Virginia Tech', Hemisphere.North,
+                                  100, [48, -60], [54, 23], read_hdw_file('gbr')),
+              RadarID.HAN: _Radar('Hankasalmi', 'University of Leicester',
+                                  Hemisphere.North, 70, [57, 27], [54, 102],
+                                  read_hdw_file('han')),
+              RadarID.HJE: _Radar('Hejing East',
                          'National Space Science Center,'
                          'Chinese Academy of Sciences',
-                         Hemisphere.North, 100, [40, 87], [36, 163],
-                         read_hdw_file('hje')),
-              56: _Radar('Hejing West',
+                                  Hemisphere.North, 100, [40, 87], [36, 163],
+                                  read_hdw_file('hje')),
+              RadarID.HJW: _Radar('Hejing West',
                          'National Space Science Center,'
                          'Chinese Academy of Sciences',
-                         Hemisphere.North, 100, [40, 81], [36, 153],
-                         read_hdw_file('hjw')),
-              40: _Radar('Hokkaido East', 'Nagoya University',
-                         Hemisphere.North, 110, [39, 149], [35, -139],
-                         read_hdw_file('hok')),
-              41: _Radar('Hokkaido West', 'Nagoya University',
-                         Hemisphere.North, 110, [39, 139], [35, -149],
-                         read_hdw_file('hkw')),
-              211: _Radar('Iceland East', 'Dartmouth College',
-                         Hemisphere.North, 100, [61, -16], [60, 70],
-                         read_hdw_file('ice')),
-              210: _Radar('Iceland West', 'Dartmouth College',
-                         Hemisphere.North, 100, [61, -26], [60, 60],
-                         read_hdw_file('icw')),
-              64: _Radar('Inuvik', 'University of Saskatchewan',
-                         Hemisphere.North, 75, [63, -134], [66, -80],
-                         read_hdw_file('inv')),
-              50: _Radar('Jiamusi East',
+                                  Hemisphere.North, 100, [40, 81], [36, 153],
+                                  read_hdw_file('hjw')),
+              RadarID.HOK: _Radar('Hokkaido East', 'Nagoya University',
+                                  Hemisphere.North, 110, [39, 149], [35, -139],
+                                  read_hdw_file('hok')),
+              RadarID.HKW: _Radar('Hokkaido West', 'Nagoya University',
+                                  Hemisphere.North, 110, [39, 139], [35, -149],
+                                  read_hdw_file('hkw')),
+              RadarID.ICE: _Radar('Iceland East', 'Dartmouth College',
+                                  Hemisphere.North, 100, [61, -16], [60, 70],
+                                  read_hdw_file('ice')),
+              RadarID.ICW: _Radar('Iceland West', 'Dartmouth College',
+                                  Hemisphere.North, 100, [61, -26], [60, 60],
+                                  read_hdw_file('icw')),
+              RadarID.INV: _Radar('Inuvik', 'University of Saskatchewan',
+                                  Hemisphere.North, 75, [63, -134], [66, -80],
+                                  read_hdw_file('inv')),
+              RadarID.JME: _Radar('Jiamusi East',
                          'National Space Science Center,'
                          'Chinese Academy of Sciences',
-                         Hemisphere.North, 100, [42, 130], [37, -155],
-                         read_hdw_file('jme')),
-              3: _Radar('Kapuskasing', 'Virginia Tech', Hemisphere.North,
-                        75, [44, -82], [54, -7], read_hdw_file('kap')),
-              16: _Radar('King Salmon',
+                                  Hemisphere.North, 100, [42, 130], [37, -155],
+                                  read_hdw_file('jme')),
+              RadarID.KAP: _Radar('Kapuskasing', 'Virginia Tech', Hemisphere.North,
+                                  75, [44, -82], [54, -7], read_hdw_file('kap')),
+              RadarID.KSR: _Radar('King Salmon',
                          'National Institute of Information and'
                          ' Communications Technology', Hemisphere.North,
-                         75, [54, -162], [52, -99], read_hdw_file('ksr')),
-              7: _Radar('Kodiak', 'University of Alaska Fairbanks',
-                        Hemisphere.North, 110, [53, -152], [52, -92],
-                        read_hdw_file('kod')),
-              51: _Radar('Longjing East',
+                                  75, [54, -162], [52, -99], read_hdw_file('ksr')),
+              RadarID.KOD: _Radar('Kodiak', 'University of Alaska Fairbanks',
+                                  Hemisphere.North, 110, [53, -152], [52, -92],
+                                  read_hdw_file('kod')),
+              RadarID.LJE: _Radar('Longjing East',
                          'National Space Science Center,'
                          'Chinese Academy of Sciences',
-                         Hemisphere.North, 100, [39, 132], [32, -151],
-                         read_hdw_file('lje')),
-              52: _Radar('Longjing West',
+                                  Hemisphere.North, 100, [39, 132], [32, -151],
+                                  read_hdw_file('lje')),
+              RadarID.LJW: _Radar('Longjing West',
                          'National Space Science Center,'
                          'Chinese Academy of Sciences',
-                         Hemisphere.North, 100, [39, 126], [42, -161],
-                         read_hdw_file('ljw')),
-              90: _Radar('Longyearbyen', 'University of Centre in Svalbard',
-                         Hemisphere.North, 70, [73, 16], [71, 108],
-                         read_hdw_file('lyr')),
-              9: _Radar('Pykkvibaer', 'University of Leicester',
-                        Hemisphere.North, 70, [58, -19], [56, 75],
-                        read_hdw_file('pyk')),
-              6: _Radar('Prince George', 'University of Saskatchewan',
-                        Hemisphere.North, 75, [49, -123], [55, -61],
-                        read_hdw_file('pgr')),
-              65: _Radar('Rankin Inlet', 'University of Saskatchewan',
-                         Hemisphere.North, 75, [58, -92], [66, -21],
-                         read_hdw_file('rkn')),
-              5: _Radar('Saskatoon', 'University of Saskatchewan',
-                        Hemisphere.North, 75, [47, -107], [56, -41],
-                        read_hdw_file('sas')),
-              2: _Radar('Schefferville', 'CNRS/LPCE', Hemisphere.North,
-                        75, [50, -67], [60, 14], read_hdw_file('sch')),
-              53: _Radar('Siziwanqi East',
+                                  Hemisphere.North, 100, [39, 126], [42, -161],
+                                  read_hdw_file('ljw')),
+              RadarID.LYR: _Radar('Longyearbyen', 'University of Centre in Svalbard',
+                                  Hemisphere.North, 70, [73, 16], [71, 108],
+                                  read_hdw_file('lyr')),
+              RadarID.PYK: _Radar('Pykkvibaer', 'University of Leicester',
+                                  Hemisphere.North, 70, [58, -19], [56, 75],
+                                  read_hdw_file('pyk')),
+              RadarID.PGR: _Radar('Prince George', 'University of Saskatchewan',
+                                  Hemisphere.North, 75, [49, -123], [55, -61],
+                                  read_hdw_file('pgr')),
+              RadarID.RKN: _Radar('Rankin Inlet', 'University of Saskatchewan',
+                                  Hemisphere.North, 75, [58, -92], [66, -21],
+                                  read_hdw_file('rkn')),
+              RadarID.SAS: _Radar('Saskatoon', 'University of Saskatchewan',
+                                  Hemisphere.North, 75, [47, -107], [56, -41],
+                                  read_hdw_file('sas')),
+              RadarID.SCH: _Radar('Schefferville', 'CNRS/LPCE', Hemisphere.North,
+                                  75, [50, -67], [60, 14], read_hdw_file('sch')),
+              RadarID.SZE: _Radar('Siziwanqi East',
                          'National Space Science Center,'
                          'Chinese Academy of Sciences',
-                         Hemisphere.North, 100, [38, 115], [37, -169],
-                         read_hdw_file('sze')),
-              54: _Radar('Siziwanqi West',
+                                  Hemisphere.North, 100, [38, 115], [37, -169],
+                                  read_hdw_file('sze')),
+              RadarID.SZW: _Radar('Siziwanqi West',
                          'National Space Science Center,'
                          'Chinese Academy of Sciences',
-                         Hemisphere.North, 100, [38, 109], [37, -179],
-                         read_hdw_file('szw')),
-              8: _Radar('Stokkseyri', 'Lancaster University',
-                        Hemisphere.North, 75, [58, -29], [56, 65],
-                        read_hdw_file('sto')),
-              32: _Radar('Wallops Island', 'JHU Applied Physics Laboratory',
-                         Hemisphere.North, 100, [33, -75], [44, 5],
-                         read_hdw_file('wal')),
-              24: _Radar('Buckland Park', 'La Trobe University',
-                         Hemisphere.South, 75, [-30, 138], [-40, -146],
-                         read_hdw_file('bpk')),
-              96: _Radar('Dome C East',
+                                  Hemisphere.North, 100, [38, 109], [37, -179],
+                                  read_hdw_file('szw')),
+              RadarID.STO: _Radar('Stokkseyri', 'Lancaster University',
+                                  Hemisphere.North, 75, [58, -29], [56, 65],
+                                  read_hdw_file('sto')),
+              RadarID.WAL: _Radar('Wallops Island', 'JHU Applied Physics Laboratory',
+                                  Hemisphere.North, 100, [33, -75], [44, 5],
+                                  read_hdw_file('wal')),
+              RadarID.BPK: _Radar('Buckland Park', 'La Trobe University',
+                                  Hemisphere.South, 75, [-30, 138], [-40, -146],
+                                  read_hdw_file('bpk')),
+              RadarID.DCE: _Radar('Dome C East',
                          'Institute for Space Astrophysics and Planetology',
-                         Hemisphere.South, 75, [-80, 130], [-83, 0],
-                         read_hdw_file('dce')),
-              97: _Radar('Dome C North',
+                                  Hemisphere.South, 75, [-80, 130], [-83, 0],
+                                  read_hdw_file('dce')),
+              RadarID.DCN: _Radar('Dome C North',
                          'Institute for Space Astrophysics and Planetology',
-                         Hemisphere.South, 75, [-75, 112], [-85, 90],
-                         read_hdw_file('dcn')),
-              21: _Radar('Falkland Islands', 'British Antarctic Survey',
-                         Hemisphere.South,  110, [-47, -59], [-35, 10],
-                         read_hdw_file('fir')),
-              4: _Radar('Halley', 'British Antarctic Survey',
-                        Hemisphere.South, 100, [-71, -27], [-58, 30],
-                        read_hdw_file('hal')),
-              15: _Radar('Kerguelen', 'IRAP/CNRS/IPEV', Hemisphere.South,
-                         75, [-44, 70], [-53, 124], read_hdw_file('ker')),
-              20: _Radar('McMurdo', 'University of Alaska, Fairbanks',
-                         Hemisphere.South, 75, [-78, 187], [-75, -36],
-                         read_hdw_file('mcm')),
-              11: _Radar('SANAE', 'South African National Space Agency',
-                         Hemisphere.South, 110, [-67, -3], [-60, 45],
-                         read_hdw_file('san')),
-              22: _Radar('South Pole Station',
+                                  Hemisphere.South, 75, [-75, 112], [-85, 90],
+                                  read_hdw_file('dcn')),
+              RadarID.FIR: _Radar('Falkland Islands', 'British Antarctic Survey',
+                                  Hemisphere.South, 110, [-47, -59], [-35, 10],
+                                  read_hdw_file('fir')),
+              RadarID.HAL: _Radar('Halley', 'British Antarctic Survey',
+                                  Hemisphere.South, 100, [-71, -27], [-58, 30],
+                                  read_hdw_file('hal')),
+              RadarID.KER: _Radar('Kerguelen', 'IRAP/CNRS/IPEV', Hemisphere.South,
+                                  75, [-44, 70], [-53, 124], read_hdw_file('ker')),
+              RadarID.MCM: _Radar('McMurdo', 'University of Alaska, Fairbanks',
+                                  Hemisphere.South, 75, [-78, 187], [-75, -36],
+                                  read_hdw_file('mcm')),
+              RadarID.SAN: _Radar('SANAE', 'South African National Space Agency',
+                                  Hemisphere.South, 110, [-67, -3], [-60, 45],
+                                  read_hdw_file('san')),
+              RadarID.SPS: _Radar('South Pole Station',
                          'University of Alaska, Fairbanks', Hemisphere.South,
-                         75, [-87, 12], [-74, 25], read_hdw_file('sps')),
-              13: _Radar('Syowa East', 'National Institute of Polar Research',
-                         Hemisphere.South, 75, [-64, 45], [-62, 82],
-                         read_hdw_file('sye')),
-              12: _Radar('Syowa South', 'National Institute of Polar Research',
-                         Hemisphere.South, 80, [-66, 30], [-62, 68],
-                         read_hdw_file('sys')),
-              14: _Radar('Tiger', 'La Trobe University', Hemisphere.South,
-                         75, [-38, 147], [-49, -133], read_hdw_file('tig')),
-              18: _Radar('Unwin', 'La Trobe University', Hemisphere.South,
-                         75, [-42, 168], [-49, -105], read_hdw_file('unw')),
-              19: _Radar('Zhongshan', 'Polar Research Institute of China',
-                         Hemisphere.South, 70, [-67, 64], [-70, 99],
-                         read_hdw_file('zho'))}
+                                  75, [-87, 12], [-74, 25], read_hdw_file('sps')),
+              RadarID.SYE: _Radar('Syowa East', 'National Institute of Polar Research',
+                                  Hemisphere.South, 75, [-64, 45], [-62, 82],
+                                  read_hdw_file('sye')),
+              RadarID.SYS: _Radar('Syowa South', 'National Institute of Polar Research',
+                                  Hemisphere.South, 80, [-66, 30], [-62, 68],
+                                  read_hdw_file('sys')),
+              RadarID.TIG: _Radar('Tiger', 'La Trobe University', Hemisphere.South,
+                                  75, [-38, 147], [-49, -133], read_hdw_file('tig')),
+              RadarID.UNW: _Radar('Unwin', 'La Trobe University', Hemisphere.South,
+                                  75, [-42, 168], [-49, -105], read_hdw_file('unw')),
+              RadarID.ZHO: _Radar('Zhongshan', 'Polar Research Institute of China',
+                                  Hemisphere.South, 70, [-67, 64], [-70, 99],
+                                  read_hdw_file('zho'))}

--- a/test/test_Fan.py
+++ b/test/test_Fan.py
@@ -35,10 +35,10 @@ class TestFan_defaults:
     def test_fov_series(self):
         """ """
         with warnings.catch_warnings(record=True):
-            pydarn.Fan.plot_fov(6, dt.datetime(2020, 4, 4, 6, 2))
+            pydarn.Fan.plot_fov(pydarn.RadarID.PGR, dt.datetime(2020, 4, 4, 6, 2))
 
 
-@pytest.mark.parametrize('stid', [5, 97])
+@pytest.mark.parametrize('stid', [pydarn.RadarID.SAS, pydarn.RadarID.DCN])
 @pytest.mark.parametrize('ranges', [(5,70)])
 @pytest.mark.parametrize('boundary', [False])
 @pytest.mark.parametrize('rsep', [15])


### PR DESCRIPTION
# Scope 

Adds an enum to facilitate easy access to station IDs for radars.

**issue:** #406 

## Approval

**Number of approvals:** 1

## Test

**matplotlib version**: 3.9.2

- [ ] `pydarn.Fan.plot_fov`, using `stid=pydarn.RadarID.XXX`
- [ ] `pydarn.Fan.plot_fan_input`, using `stid=pydarn.RadarID.XXX`
