### PR TITLE
RTP terminator

### DIFF
--- a/docs/user/range_time.md
+++ b/docs/user/range_time.md
@@ -96,20 +96,21 @@ plt.show()
 ### Additional options
 To see all the customisation options, check out all the parameters listed in 'rtp.py'. A few useful ones:
 
-| Parameter                    | Action                                                      |
-|------------------------------|-------------------------------------------------------------|
-| start_time=(datetime object) | Control the start time of the plot                          |
-| end_time=(datetime object)   | Control the end time of the plot                            |
-| channel=(int or string)      | Choose which channel to plot. Default is 'all'.             |
-| groundscatter=(bool)         | True or false to showing ground scatter as grey             |
-| date_fmt=(string)            | How the x-tick labels look. Default is ('%y/%m/%d\n %H:%M') |
-| zmin=(int)                   | Minimum data value to be plotted                            |
-| zmax=(int)                   | Maximum data value to be plotted                            |
-| range_estimation=(RangeEstimation)              | Estaimtion of the distance for the radar to use for the y-axis (See [Ranges, Coords and Projs](coordinates.md)) |
-| coords=(Coords)              | Used in conjunction with range_estimation, converts the y-axis to a coordinate |
-| lat_or_lon=(str)             | In conjunction with coords, choose if you would like the latitude ('lat') or longitude ('lon') |
-| colorbar=(plt.colorbar)      | If you would like a different colorbar than the default     |
-| colorbar_label=(str)         | Set the label fo the colorbar                               |
+| Parameter                          | Action                                                                                                          |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| start_time=(datetime object)       | Control the start time of the plot                                                                              |
+| end_time=(datetime object)         | Control the end time of the plot                                                                                |
+| channel=(int or string)            | Choose which channel to plot. Default is 'all'.                                                                 |
+| groundscatter=(bool)               | True or false to showing ground scatter as grey                                                                 |
+| date_fmt=(string)                  | How the x-tick labels look. Default is ('%y/%m/%d\n %H:%M')                                                     |
+| zmin=(int)                         | Minimum data value to be plotted                                                                                |
+| zmax=(int)                         | Maximum data value to be plotted                                                                                |
+| range_estimation=(RangeEstimation) | Estaimtion of the distance for the radar to use for the y-axis (See [Ranges, Coords and Projs](coordinates.md)) |
+| coords=(Coords)                    | Used in conjunction with range_estimation, converts the y-axis to a coordinate                                  |
+| lat_or_lon=(str)                   | In conjunction with coords, choose if you would like the latitude ('lat') or longitude ('lon')                  |
+| colorbar=(plt.colorbar)            | If you would like a different colorbar than the default                                                         |
+| colorbar_label=(str)               | Set the label fo the colorbar                                                                                   |
+| terminator=(bool)                  | Turn on shading of the day-night terminator                                                                     |
 
 For instance, code for a velocity RTP showing the same beam of Clyde river radar as above, but with ground scatter plotted in grey, date format as `hh:mm`, custom min and max values and a colour bar label could look something like:
 ```python

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -277,7 +277,7 @@ class RTP:
         # because nrang can change based on mode we need to look
         # for the largest value
         y_max = max(record['nrang'] for record in cls.dmap_data)
-        y = np.arange(0, y_max+1, 1)
+        range_gates = np.arange(0, y_max+1, 1)
 
         # z: parameter data mapped into the color mesh
         z = np.zeros((1, y_max)) * np.nan
@@ -405,6 +405,9 @@ class RTP:
             y0inx = np.min(np.where(np.isfinite(y))[0])
             y = y[y0inx:]
             z = z[:, y0inx:]
+            range_gates = range_gates[y0inx:]
+        else:
+            y = range_gates
 
         time_axis, y_axis = np.meshgrid(x, y)
         z_data = np.ma.masked_where(np.isnan(z.T), z.T)
@@ -461,7 +464,7 @@ class RTP:
             # [num_ranges, 2] holding the [lat, lon] for each range gate
             geographic_points = np.array([
                 gate2geographic_location(cls.dmap_data[0]["stid"], beam_num, height, center=True, range_gate=rg)
-                for rg in y
+                for rg in range_gates
             ])
             # switch to [lon, lat] for compatibility with cartopy geodesic calculations
             geographic_points = np.flip(geographic_points, axis=1)
@@ -547,7 +550,7 @@ class RTP:
         ax.margins(0)
 
         # Create color bar if None supplied
-        if not colorbar:
+        if colorbar is None:
             with warnings.catch_warnings():
                 warnings.filterwarnings('error')
                 try:
@@ -576,7 +579,8 @@ class RTP:
         else:
             cb = colorbar
         if colorbar_label != '':
-            cb.set_label(colorbar_label)
+            if cb is not False:
+                cb.set_label(colorbar_label)
 
         if determine_embargo(end_time, dmap_data[-1]['cp'],
                              SuperDARNRadars.radars[dmap_data[-1]['stid']].name):
@@ -1483,7 +1487,7 @@ class RTP:
     @classmethod
     def plot_coord_time(cls, dmap_data: List[dict], parameter: str = 'v',
                         beam_num: int = 0, channel: int = 'all', ax=None,
-                        background: str = 'w', background_alpha: float = 1.0,
+                        background: str = 'w', background_alpha: float = 0.0,
                         groundscatter: bool = False,
                         zmin: int = None, zmax: int = None,
                         coords: object = Coords.AACGM, latlon: str = 'lat',
@@ -1497,7 +1501,9 @@ class RTP:
                         filter_settings: dict = {},
                         date_fmt: str = '%y/%m/%d\n %H:%M',
                         round_start: bool = True,
-                        plot_equatorward: bool = False, **kwargs):
+                        plot_equatorward: bool = False,
+                        terminator: bool = False,
+                        **kwargs):
         """
         Plots a range-time parameter plot of the given
         field name in the dmap_data using coordinates in latitude and
@@ -1534,7 +1540,7 @@ class RTP:
             default: white
         background_alpha : float
             alpha (transparency) of the background in the plot
-            default: 1.0 (opaque)
+            default: 0.0 (transparent)
         zmin: int
             Minimum normalized value
             Default: minimum parameter value in the data set
@@ -1616,6 +1622,8 @@ class RTP:
                 direction to plot the equator-ward or pole-ward data
                 No option to overplot.
                 Default: False (plot poleward data only)
+        terminator: bool=False
+                Flag to include the terminator (day/night boundary) and shade the night-side
         kwargs:
             used for other methods in pyDARN
                 - reflection_height
@@ -1690,7 +1698,7 @@ class RTP:
         # because nrang can change based on mode we need to look
         # for the largest value
         y_max = max(record['nrang'] for record in cls.dmap_data)
-        y = np.arange(0, y_max+1, 1)
+        range_gates = np.arange(0, y_max, 1)
 
         # z: parameter data mapped into the color mesh
         z = np.zeros((1, y_max)) * np.nan
@@ -1763,7 +1771,7 @@ class RTP:
 
                     # insert a new column into the z_data
                     if i > 0:
-                        z = np.insert(z, len(z), np.zeros(1, y_max) * np.nan,
+                        z = np.insert(z, len(z), np.zeros((1, y_max)) * np.nan,
                                       axis=0)
                     try:
                         if len(dmap_record[parameter]) == dmap_record['nrang']:
@@ -1820,6 +1828,13 @@ class RTP:
                            gates=[0, dmap_data[0]['nrang']],
                            range_estimation=range_estimation, **kwargs)
 
+        # coords may not return the same number of points as passed in by `gates=...`
+        # The dropped gates are always at the start of the array, so we drop down our `z` and
+        # `range_gates` arrays to match
+        num_gates = len(lats) - 1
+        z = z[:, -num_gates-1:-1]
+        range_gates = range_gates[-num_gates-1:-1]
+
         if latlon == 'lat':
             y = lats[:, beam_num]
             # If the FOV is over the pole, only plot up to the pole to avoid
@@ -1840,6 +1855,7 @@ class RTP:
                             'use the keyword plot_equatorward=True.'
                             .format(yind,))
                 y = y[:yind]
+                range_gates = range_gates[:yind]
                 y = np.append(y, y[-1])
                 z = z[:, :yind]
             if any(x < 0 for x in diff_y) and plot_equatorward:
@@ -1851,6 +1867,7 @@ class RTP:
                             'use the keyword plot_equatorward=False.'
                             .format(yind))
                 y = y[yind-1:]
+                range_gates = range_gates[yind-1:]
                 z = z[:, yind-1:]
         elif latlon == 'lon':
             y = lons[:, beam_num]
@@ -1907,6 +1924,32 @@ class RTP:
             gs_color = colors.ListedColormap(['grey'])
             ax.pcolormesh(time_axis, y_axis, ground_scatter, lw=0.01,
                           cmap=gs_color, norm=norm, **kwargs)
+
+        if terminator:
+            height = 300  # km
+
+            # [num_ranges, 2] holding the [lat, lon] for each range gate
+            geographic_points = np.array([
+                gate2geographic_location(cls.dmap_data[0]["stid"], beam_num, height, center=True, range_gate=rg)
+                for rg in range_gates
+            ])
+            # switch to [lon, lat] for compatibility with cartopy geodesic calculations
+            geographic_points = np.flip(geographic_points, axis=1)
+
+            # [num_times, num_ranges] indicating if the cell is in darkness at that time
+            is_night = np.zeros((len(range_gates), time_axis.shape[1]), dtype=np.int8)
+            geodesic = cartopy.geodesic.Geodesic()
+            for i, t in enumerate(x):
+                anti_point, arc_ang, _ = calc_terminator(t, height)
+                distance_to_antisolar_point = geodesic.inverse(anti_point, geographic_points)[:, 0] / 1000.0  # convert to km
+                is_night[:, i] = distance_to_antisolar_point < arc_ang
+            ax.pcolormesh(time_axis, y_axis, is_night[:, :-1],
+                          cmap=colors.ListedColormap(['white', 'gray']),
+                          shading='flat',
+                          zorder=0.5,
+                          vmin=0,
+                          vmax=1,
+                          alpha=0.7)
 
         # setup some standard axis information
         if ymax is None:
@@ -1971,11 +2014,6 @@ class RTP:
         if y[0] < 0 and latlon == 'lat':
             ax.invert_yaxis()
 
-        if range_estimation != RangeEstimation.RANGE_GATE:
-            ax.yaxis.set_minor_locator(ticker.AutoMinorLocator(2))
-        else:
-            ax.yaxis.set_minor_locator(ticker.MultipleLocator(5))
-        # so the plots gets to the ends
         ax.margins(0)
 
         # Create color bar if None supplied

--- a/pydarn/plotting/rtp.py
+++ b/pydarn/plotting/rtp.py
@@ -1832,8 +1832,9 @@ class RTP:
         # The dropped gates are always at the start of the array, so we drop down our `z` and
         # `range_gates` arrays to match
         num_gates = len(lats) - 1
-        z = z[:, -num_gates-1:-1]
-        range_gates = range_gates[-num_gates-1:-1]
+        if num_gates != len(range_gates):
+            z = z[:, -(num_gates + 1):-1]
+            range_gates = range_gates[-(num_gates+1):-1]
 
         if latlon == 'lat':
             y = lats[:, beam_num]
@@ -1937,7 +1938,7 @@ class RTP:
             geographic_points = np.flip(geographic_points, axis=1)
 
             # [num_times, num_ranges] indicating if the cell is in darkness at that time
-            is_night = np.zeros((len(range_gates), time_axis.shape[1]), dtype=np.int8)
+            is_night = np.zeros((len(range_gates), time_axis.shape[1]), dtype=bool)
             geodesic = cartopy.geodesic.Geodesic()
             for i, t in enumerate(x):
                 anti_point, arc_ang, _ = calc_terminator(t, height)
@@ -1945,11 +1946,12 @@ class RTP:
                 is_night[:, i] = distance_to_antisolar_point < arc_ang
             ax.pcolormesh(time_axis, y_axis, is_night[:, :-1],
                           cmap=colors.ListedColormap(['white', 'gray']),
-                          shading='flat',
+                          shading='auto',
                           zorder=0.5,
                           vmin=0,
                           vmax=1,
-                          alpha=0.7)
+                          alpha=0.5
+                          )
 
         # setup some standard axis information
         if ymax is None:


### PR DESCRIPTION
# Scope 

Addition of terminator plotting (shading the nightside cells) on RTP plots.

![Screenshot from 2024-10-11 19-06-10](https://github.com/user-attachments/assets/efcdffcf-8374-4d67-a88e-65178cf47806)

**issue:** closes #321 

## Approval

**Number of approvals:** 1

## Test

**matplotlib version**: 3.9.15

Try out different options for `RTP.plot_range_time()`, `RTP.plot_coord_time()` functions with `terminator=True`.

E.g.
```python3
import dmap
from pydarn import RTP, RangeEstimation, Coords
import matplotlib.pyplot as plt


if __name__ == '__main__':
    data = dmap.read_fitacf('fitacf/20211102.0000.00.rkn.a.fitacf')

    fig, axes = plt.subplots(1, 3, figsize=(10,6))
    RTP.plot_range_time(data, ax=axes[0], beam_num=3, range_estimation=RangeEstimation.RANGE_GATE, terminator=True, groundscatter=True, colorbar=False)
    RTP.plot_range_time(data, ax=axes[1], beam_num=3, range_estimation=RangeEstimation.SLANT_RANGE, terminator=True, groundscatter=True, colorbar=False)
    RTP.plot_range_time(data, ax=axes[2], beam_num=3, range_estimation=RangeEstimation.GSMR, terminator=True, groundscatter=True)
    axes[0].set_ylabel("Range Gate")
    axes[1].set_ylabel("Slant Range")
    axes[2].set_ylabel("GSMR")
    plt.show()
    plt.close()

    fig, axes = plt.subplots(2, 2, figsize=(10, 10))
    RTP.plot_coord_time(data, ax=axes[0, 0], beam_num=3, range_estimation=RangeEstimation.GSMR, coords=Coords.GEOGRAPHIC, terminator=True, latlon='lat')
    RTP.plot_coord_time(data, ax=axes[0, 1], beam_num=3, range_estimation=RangeEstimation.SLANT_RANGE, coords=Coords.GEOGRAPHIC, terminator=True, latlon='lat')
    RTP.plot_coord_time(data, ax=axes[1, 0], beam_num=3, range_estimation=RangeEstimation.GSMR, coords=Coords.AACGM, terminator=True, latlon='lon')
    RTP.plot_coord_time(data, ax=axes[1, 1], beam_num=3, range_estimation=RangeEstimation.SLANT_RANGE, coords=Coords.AACGM, terminator=True, latlon='lon')
    plt.show()
    plt.close()
```
