### PR TITLE
Replaced deprecated `InsetPosition` import and usage.

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -29,13 +29,14 @@ Grid plots, mapped to AACGM coordinates in a polar format
 """
 
 import datetime as dt
+
+import matplotlib.axes
 import matplotlib.pyplot as plt
 import numpy as np
 import warnings
 
 from enum import Enum
 from matplotlib import ticker, cm, colors
-from mpl_toolkits.axes_grid1.inset_locator import InsetPosition
 from scipy import special
 from typing import List
 
@@ -50,7 +51,7 @@ from pydarn import (PyDARNColormaps, plot_exceptions,
 warnings.formatwarning = standard_warning_format
 
 
-class Maps():
+class Maps:
     """
     Maps plots for SuperDARN data
 
@@ -854,7 +855,7 @@ class Maps():
         return mlon, mlats
 
     @classmethod
-    def plot_imf_dial(cls, ax: object, by: float = 0, bz: float = 0,
+    def plot_imf_dial(cls, ax: matplotlib.axes.Axes, by: float = 0, bz: float = 0,
                       bt: float = 0, delay: float = 0):
         """
         Plots an IMF clock angle dial on the existing plot
@@ -879,9 +880,7 @@ class Maps():
                 Default = 0 minutes
         """
         # Create new axes inside existing axes
-        ax_imf = plt.axes([0, 0, 1, 1])
-        ip = InsetPosition(ax, [-0.2, 0.7, 0.4, 0.4])
-        ax_imf.set_axes_locator(ip)
+        ax_imf = ax.inset_axes((-0.2, 0.7, 0.4, 0.4))
         ax_imf.axis('off')
 
         ax_imf.set_xlim([-20.2, 20.2])
@@ -892,11 +891,11 @@ class Maps():
                                   edgecolor='k')
         ax_imf.add_patch(limit_circle)
         # Plot axis lines
-        plt.plot([-10, 10], [0, 0], color='k', linewidth=0.5)
-        plt.plot([0, 0], [-10, 10], color='k', linewidth=0.5)
+        ax_imf.plot([-10, 10], [0, 0], color='k', linewidth=0.5)
+        ax_imf.plot([0, 0], [-10, 10], color='k', linewidth=0.5)
 
         # Plot line for magnetic field
-        plt.plot([0, by], [0, bz], color='r')
+        ax_imf.plot([0, by], [0, bz], color='r')
 
         # Add axis labels
         ax_imf.annotate('+Z', xy=(-2.5, 11))


### PR DESCRIPTION
# Scope 

Fix when installing pydarn with matplotlib v3.10

**issue:** #410 

## Approval

**Number of approvals:** 1

## Test

**matplotlib version**: 3.10

Import pydarn and plot a map file **including** the IMF dial (does so by default).