### PR TITLE
modified to use scipy 1.16.3 and pydarnio 2.0. passes all tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Python data visualization library for the Super Dual Auroral Radar Network (Supe
 
 This patch release includes:
 - matplotlib v3.10 support (fixed incompatibility)
-- scipy dependency capped at v1.14.1
+- scipy dependency updated to support v1.16.x
 - **NEW** `marker` and `markersize` kwargs for `pydarn.Fan.plot_radar_position()`
 - **NEW** `pydarn.RadarID` enum abstracting away the station ID numbers of each radar
 

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -59,7 +59,7 @@ You can check your python version using
 On installation, pyDARN will download the following dependencies: 
 
 - [NumPy](https://numpy.org/)
-- [scipy 1.15.0+](https://scipy.org/)
+- [scipy 1.14.0+](https://scipy.org/) (tested with 1.16.3)
 - [matplotlib 3.7.0+](https://matplotlib.org/) 
 - [PyYAML](https://pyyaml.org/wiki/PyYAMLDocumentation)
 - [pyDARNio 2.0.0+](https://pydarnio.readthedocs.io/en/latest/user/install/)

--- a/pydarn/__init__.py
+++ b/pydarn/__init__.py
@@ -22,15 +22,21 @@ from .version import __version__
 
 # Import io for pyDARN
 from .io.superdarn_io import read_borealis
-from pydarnio import (
-    read_iqdat,
-    read_rawacf,
-    read_fitacf,
-    read_grid,
-    read_map,
-    read_snd,
-    read_dmap,
-)
+import pydarnio
+
+read_rawacf = pydarnio.read_rawacf
+read_fitacf = pydarnio.read_fitacf
+read_grid = pydarnio.read_grid
+read_map = pydarnio.read_map
+read_snd = pydarnio.read_snd
+read_dmap = pydarnio.read_dmap
+
+read_iqdat = getattr(pydarnio, "read_iqdat", None)
+if read_iqdat is None:
+    def read_iqdat(*args, **kwargs):  # type: ignore
+        raise ImportError("read_iqdat is not available in the installed "
+                          "pydarnio package; install a version with iqdat "
+                          "support to use this function.")
 
 # Importing pydarn exception classes
 from .exceptions import rtp_exceptions, plot_exceptions, radar_exceptions

--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -259,7 +259,7 @@ class Maps:
 
         # Arbitrary lon used to calculate the shift required
         shifted_mlts = 0 - (aacgmv2.convert_mlt(0, date) * 15)
-        shifted_lons = data_lons - shifted_mlts
+        shifted_lons = (data_lons - shifted_mlts) % 360
         # Note that this "mlons" is adjusted for MLT
         mlons = np.radians(shifted_lons)
         mlats = data_lats
@@ -1212,8 +1212,12 @@ class Maps:
         # Shift mlon to MLT
         shifted_mlts = mlon_u[0, 0] - \
             (aacgmv2.convert_mlt(mlon_u[0, 0], date) * 15)
-        shifted_lons = mlon_u - shifted_mlts
-        mlon = shifted_lons
+        shifted_lons = (mlon_u - shifted_mlts) % 360
+        # Sort longitudes so the contour grid wraps only once around the pole
+        sort_idx = np.argsort(shifted_lons[:, 0])
+        mlon = shifted_lons[sort_idx]
+        mlat = mlat[sort_idx]
+        pot_arr = pot_arr[sort_idx]
 
         # Contained in function as too long to go into the function call
         if contour_levels == []:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     matplotlib>=3.7.0
     aacgmv2
     pydarnio>=2.0.0
-    scipy<1.15.0
+    scipy>=1.14,<2.0
     cartopy>=0.22.0
 
 [options.packages.find]

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1,0 +1,15 @@
+import pydarn
+import dmap  # pip install darn-dmap
+import matplotlib.pyplot as plt
+
+map_file = "/Users/chartat1/Downloads/20180501.n.map"
+map_data = dmap.read_map(map_file)
+pydarn.Maps.plot_mapdata(
+    map_data,
+    record=15,
+    parameter=pydarn.MapParams.RAW_VELOCITY,
+    lowlat=50,
+    contour_fill=True,
+    contour_colorbar=True,
+)
+plt.show()


### PR DESCRIPTION
# Scope 

*allows pydarn to run with the new scipy (1.16.3) and pydarnio 2.0. Seems to pass all the built-in tests in my M2 mac environment with python 3.14*

*Reminder, please check your code is:
  - copyrighted (if applicable)
  - Appropriate disclaimer added
  - Modification line filled in (if applicable)*
