### PR TITLE
FIX: restrict scipy to >=1.17 and update Legendre code

### DIFF
--- a/pydarn/plotting/maps.py
+++ b/pydarn/plotting/maps.py
@@ -638,7 +638,8 @@ class Maps:
         # i is the index of the list
         # x_i is the element of x at ith index
         for i, x_i in enumerate(x):
-            temp_poly = special.lpmn(fit_order, fit_order, x_i)
+            temp_poly = special.assoc_legendre_p_all(fit_order, fit_order, x_i)
+            temp_poly = ((temp_poly[0].T).tolist()[0:fit_order+1],)
             if i == 0:
                 legendre_poly = np.append([temp_poly[0]], [temp_poly[0]],
                                           axis=0)
@@ -973,7 +974,8 @@ class Maps:
         x = np.cos(alpha*theta)
         # Legendre Polys
         for j, xj in enumerate(x):
-            plm_tmp = special.lpmn(fit_order, fit_order, xj)
+            plm_tmp = special.assoc_legendre_p_all(fit_order, fit_order, xj)
+            plm_tmp = ((plm_tmp[0].T).tolist()[0:fit_order+1],)
             if j == 0:
                 plm_fit = np.append([plm_tmp[0]], [plm_tmp[0]], axis=0)
             else:
@@ -1075,7 +1077,8 @@ class Maps:
 
         # Legendre Polys
         for j, xj in enumerate(x):
-            plm_tmp = special.lpmn(fit_order, fit_order, xj)
+            plm_tmp = special.assoc_legendre_p_all(fit_order, fit_order, xj)
+            plm_tmp = ((plm_tmp[0].T).tolist()[0:fit_order+1],)
             if j == 0:
                 plm_fit = np.append([plm_tmp[0]], [plm_tmp[0]], axis=0)
             else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     matplotlib>=3.7.0
     aacgmv2
     pydarnio>=2.0.0
-    scipy<1.15.0
+    scipy>=1.17.0
     cartopy>=0.22.0
 
 [options.packages.find]


### PR DESCRIPTION
# Scope 

This PR updates the pyDARN code to use the new version of the scipy.special Legendre function 'assoc_legendre_p_all' instead of the old deprecated 'lpmn' function that was replaced in version 1.15.0, but was broken for a while and is now fixed in the latest 1.17 version of scipy. 
The outputs for the new legendre functions are very different, so to reduce the changes in the code I have reworked the new output to be as similar to the old one as possible.

I tested the new code with scipy 1.15-1.16.3 but I got the issue we had before, so we would need to restrict up to 1.17 for this to work.

With the new code change, it doesn't make sense to keep the old code and if/else it as we still need to have a <1.15 >=1.17 statement anyway, where <1.15 is now 2.5+ years old anyway. 

**issue:** to close #434 

## Approval

**Number of approvals:** 2 for testing please

## Test

**matplotlib version**: 3.10.8
**python version**: 3.11
**Note testers: please indicate what version of matplotlib you are using**

```python
import pydarn
import matplotlib.pyplot as plt

date_file = '/home/carleyjm/data/map/20251001.n.map'
map_data,_ = pydarn.read_map(date_file)

plt.figure(figsize=(10,10))
pydarn.Maps.plot_mapdata(map_data, record=3, contour_fill = True, color_vectors=False, coastline=True)
plt.show()
```

Comparison between old code and scipy 1.14.0 and new code and 1.17.0:
OLD:
<img width="1000" height="972" alt="scipy1-14" src="https://github.com/user-attachments/assets/0429a7b2-77bd-4f4d-aa50-0bd071bc7fe4" />

NEW:
<img width="1000" height="972" alt="scipy1-17" src="https://github.com/user-attachments/assets/981960bc-207e-4a68-953f-4a6d6616bbb4" />

<img width="352" height="288" alt="image" src="https://github.com/user-attachments/assets/f6e8dd1d-4c40-4197-9703-63a72517f97e" />

