### PR TITLE
EHN: Vectorising `gate2geographic_location()`

### DIFF
--- a/pydarn/utils/coordinates.py
+++ b/pydarn/utils/coordinates.py
@@ -115,7 +115,7 @@ def convert2MLT(lons: float, date: object, **kwargs):
     return beam_corners_mlts
 
 
-def gate2geographic_location(stid: pydarn.RadarID, beam: int, height: float = None,
+def gate2geographic_location(stid: pydarn.RadarID, beam: int | np.typing.NDArray, height: float = None,
                              elv_angle: float = 0.0, center: bool = False,
                              range_estimation: RangeEstimation =
                              RangeEstimation.SLANT_RANGE, **kwargs):

--- a/pydarn/utils/coordinates.py
+++ b/pydarn/utils/coordinates.py
@@ -127,7 +127,7 @@ def gate2geographic_location(stid: pydarn.RadarID, beam: int, height: float = No
     ----------
         stid: pydarn.RadarID
             station id of the radar to use
-        beam: int
+        beam: int or np.array
             beam number (indexing at 0)
         height: float
             transmutation height [km]
@@ -141,6 +141,11 @@ def gate2geographic_location(stid: pydarn.RadarID, beam: int, height: float = No
             False obtains the near-left corner of the range gates.
             See also: gate2slant in range_estimation module
             default: False (return corner values)
+        range_estimation:
+            method for calulating distance.
+            default: RangeEstimation.SLANT_RANGE
+        **kwargs:
+            to be passed to range_estimation. Must include range_gate.
 
     returns
     -------
@@ -181,12 +186,12 @@ def gate2geographic_location(stid: pydarn.RadarID, beam: int, height: float = No
     # Calculate the slant range [km]
     if range_estimation == RangeEstimation.RANGE_GATE:
         raise radar_exceptions.RangeEstimationError("Range gates cannot be "
-                                                    "used in to estimate "
+                                                    "used to estimate "
                                                     "distance. Try SLANT_RANGE"
                                                     " instead.")
     elif range_estimation == RangeEstimation.TIME_OF_FLIGHT:
         raise radar_exceptions.RangeEstimationError("Time of flight cannot be "
-                                                    "used in to estimate "
+                                                    "used to estimate "
                                                     "distance. Try SLANT_RANGE"
                                                     " instead.")
     else:

--- a/pydarn/utils/geo.py
+++ b/pydarn/utils/geo.py
@@ -51,14 +51,14 @@ def geocentric_coordinates(target_range: float, psi: float, boresight: float,
             radars site latitude [rad]
         radar_lon : float
             radars site longitude [lon]
-        target_range: float
+        target_range: float or np.ndarray
             The range from the instrument to the target (echo) [km]
-        cell_height : float
+        cell_height : float or np.ndarray
             virtual height of the gate cell [km]
-        psi: int
+        psi: int or np.ndarray
             [rad]
         boresight: float
-            boresight of the radar beam [rad]
+            boresight of the radar [rad]
         virtual_height_model: VHModels
             use for choosing type of virtual height
             default: VHModels.STANDARD
@@ -87,41 +87,50 @@ def geocentric_coordinates(target_range: float, psi: float, boresight: float,
     psi_sin_2 = np.sin(psi)**2
 
     while_flag = True
-    while while_flag:
+    while np.any(while_flag):
         # distance between the gate cell to the earth's centre [km]
         cell_rho = r_cell + x_height
         # elevation angle relative to local horizon [rad]
         rel_elv = np.arcsin(((cell_rho**2) - (r_radar**2) - target_range**2) /
                             (2.0 * r_radar * target_range))
+
         # estimate elevation for multi-hop propagation
-        if virtual_height_model == VHModels.CHISHAM and target_range > 2137.5:
-            gamma = np.arccos((r_radar**2 + cell_rho**2 - target_range**2) /
-                              (2.0 * r_radar * cell_rho))
-            beta = np.arcsin(r_radar * np.sin(gamma/3.0) /
-                             (target_range/3.0))
-            # Elevation angle used for estimating off-array normal
-            # azimuth [rad]
-            xelv = (np.pi/2) - beta - (gamma/3.0)
-        else:
-            xelv = rel_elv
+        xelv = np.asarray(rel_elv, dtype=float) # Default assuming standard model
+        if virtual_height_model == VHModels.CHISHAM:
+            with np.errstate(invalid='ignore', divide='ignore'): # mute div by zero temporarily
+                gamma = np.arccos((r_radar ** 2 + cell_rho ** 2 - target_range ** 2) /
+                                  (2.0 * r_radar * cell_rho))
+                beta = np.arcsin(r_radar * np.sin(gamma / 3.0) /
+                                 (target_range / 3.0))
+                # Elevation angle used for estimating off-array normal
+                # azimuth [rad]
+                calc_xelv = (np.pi / 2) - beta - (gamma / 3.0)
+
+            # Overwrite only the elements where target_range > 2137.5
+            xelv = np.where(np.asarray(target_range) > 2137.5, calc_xelv, xelv)
+
+        # Use single float if only working with one range
+        if xelv.ndim == 0:
+            xelv = xelv.item()
 
         # Estimate the off-array-normal azimuth in radians
         elv_sin_2 = np.sin(xelv)**2
-
         est_azimuth = psi_cos_2 - elv_sin_2
-        if est_azimuth < 0:
-            tan_azimuth = 1e32
-        else:
-            # in radians
-            tan_azimuth = np.sqrt(psi_sin_2 /
-                                  (psi_cos_2 - elv_sin_2))
-        # azimuth in [rad]
-        if psi > 0:
-            azimuth = np.arctan(tan_azimuth)
-        else:
-            azimuth = -np.arctan(tan_azimuth)
 
-        # azimuth of the gate cell [rad]
+        # Need extra logic if handling an array
+        with np.errstate(divide='ignore', invalid='ignore'): # mute div by zero temporarily
+            tan_azimuth = np.where(
+                np.asarray(est_azimuth) < 0,
+                1e32,
+                np.sqrt(psi_sin_2 / (psi_cos_2 - elv_sin_2))
+            )
+        azimuth = np.arctan(tan_azimuth) * np.where(np.asarray(psi) > 0, 1, -1)
+
+        # Use single float if only working with one range
+        if azimuth.ndim == 0:
+            azimuth = azimuth.item()
+
+        # azimuth of the gate cell(s) [rad]
         cell_azimuth = azimuth + boresight
         flatten_azimuth = geocentric2flattening(delta=delta,
                                                 azimuth=cell_azimuth,
@@ -175,6 +184,13 @@ def cell_geocentric_coordinates(lat: float, lon: float, rho: float,
         lon: float
             geocentric cell longitude [rad]
     """
+
+    # Check for single inputs - will convert back at the end so it doesn't break upstream code
+    is_scalar = np.isscalar(r) and np.isscalar(elv) and np.isscalar(azimuth)
+    r = np.asarray(r, dtype=float)
+    elv = np.asarray(elv, dtype=float)
+    azimuth = np.asarray(azimuth, dtype=float)
+
     cos_lat = np.cos(np.pi/2 - lat)
     sin_lat = np.sin(np.pi/2 - lat)
 
@@ -216,13 +232,12 @@ def cell_geocentric_coordinates(lat: float, lon: float, rho: float,
     # convert Cartesian back to spherical
     rho = np.sqrt(global_x**2 + global_y**2 + global_z**2)
     lat = np.pi/2 - np.arccos(global_z/rho)
-    if global_x == 0 and global_y == 0:
-        lon = 0
-    else:
-        lon = np.arctan2(global_y, global_x)
 
+    lon = np.arctan2(global_y, global_x)
+
+    if is_scalar:
+        return rho.item(), lat.item(), lon.item()
     return rho, lat, lon
-
 
 # goecnvrt
 def geocentric2flattening(delta: float, azimuth: float, elv: float, **kwargs):

--- a/pydarn/utils/geo.py
+++ b/pydarn/utils/geo.py
@@ -37,7 +37,7 @@ import numpy as np
 from pydarn import VHModels, EARTH_EQUATORIAL_RADIUS
 
 
-def geocentric_coordinates(target_range: float, psi: float, boresight: float,
+def geocentric_coordinates(target_range: float | np.typing.NDArray, psi: float | np.typing.NDArray, boresight: float,
                            virtual_height_model: VHModels =
                            VHModels.STANDARD,
                            **kwargs):

--- a/pydarn/utils/virtual_heights.py
+++ b/pydarn/utils/virtual_heights.py
@@ -18,6 +18,7 @@
 #  2022-03-04 Marina Schmidt add the VH_Types class to the bottom
 """ virtual_heights.py comprises of different of virtual height models"""
 import enum
+import numpy as np
 
 def chisham(target_range: float, **kwargs):
     """
@@ -27,7 +28,7 @@ def chisham(target_range: float, **kwargs):
 
     Parameters
     ----------
-    target_range: float
+    target_range: float or np.array
         is the range from radar to the target (echos)
         sometimes known as slant range [km]
     kwargs: is only needed to avoid key item errors
@@ -36,23 +37,32 @@ def chisham(target_range: float, **kwargs):
     -------
     altered target_range (slant range) [km]
     """
+
+    # Check for single inputs - will convert back at the end so it doesn't break upstream code
+    is_scalar = np.isscalar(target_range)
+    x = np.asarray(target_range, dtype=float)
+    result = np.empty_like(x)
+
     # Model constants
     A_const = (108.974, 384.416, 1098.28)
     B_const = (0.0191271, -0.178640, -0.354557)
     C_const = (6.68283e-5, 1.81405e-4, 9.39961e-5)
 
-    # determine which region of ionosphere the gate
-    if target_range < 115:
-        return (target_range / 115.0) * 112.0
-    elif target_range < 787.5:
-        return A_const[0] + B_const[0] * target_range + C_const[0] *\
-                 target_range**2
-    elif target_range <= 2137.5:
-        return A_const[1] + B_const[1] * target_range + C_const[1] *\
-                 target_range**2
-    else:
-        return A_const[2] + B_const[2] * target_range + C_const[2] *\
-                 target_range**2
+    # Determine which region of ionosphere the gate is from
+    m1 = x < 115
+    result[m1] = (x[m1] / 115.0) * 112.0
+
+    m2 = (x >= 115) & (x < 787.5)
+    result[m2] = A_const[0] + B_const[0] * x[m2] + C_const[0] * x[m2] ** 2
+
+    m3 = (x >= 787.5) & (x <= 2137.5)
+    result[m3] = A_const[1] + B_const[1] * x[m3] + C_const[1] * x[m3] ** 2
+
+    m4 = x > 2137.5
+    result[m4] = A_const[2] + B_const[2] * x[m4] + C_const[2] * x[m4] ** 2
+
+    # If it was a single range, convert it back
+    return result.item() if is_scalar else result
 
 
 def standard_virtual_height(target_range: float, cell_height: int = 300,
@@ -71,7 +81,7 @@ def standard_virtual_height(target_range: float, cell_height: int = 300,
 
     Parameters
     ----------
-    target_range: float
+    target_range: float or np.array
         is the range from radar to the target (echos)
         sometimes known as slant range [km]
     cell_height: int
@@ -84,19 +94,38 @@ def standard_virtual_height(target_range: float, cell_height: int = 300,
     altered target_range (slant range) [km]
     """
     # TODO: why 115?
+
+    # Check for single inputs - will convert back at the end so it doesn't break upstream code
+    is_scalar = np.isscalar(target_range) and np.isscalar(cell_height)
+    # broadcasting handles if ones a float and ones an array
+    x, ch = np.broadcast_arrays(target_range, cell_height)
+    x = x.astype(float)
+    ch = ch.astype(float)
+    result = np.empty_like(x)
+
     # map everything into the E region
-    if cell_height <= 150 and target_range > 150:
-        return cell_height
+    m1 = (ch <= 150) & (x > 150)
+    result[m1] = ch[m1]
+
     # virtual height equation (1) from the above paper
-    elif target_range < 150:
-        return (target_range / 150.0) * 115
-    elif target_range >= 150 and target_range <= 600:
-        return 115
-    elif target_range > 600 and target_range < 800:
-        return (target_range - 600) / 200 * (cell_height - 115) + 115
-    # higher than 800 km
-    else:
-        return cell_height
+    # (m1 requires x > 150, so m1 and m2 can never overlap. No need to exclude m1.)
+    m2 = x < 150
+    result[m2] = (x[m2] / 150.0) * 115
+
+    # (x >= 150 CAN overlap with m1, so we explicitly exclude m1)
+    m3 = (~m1) & (x >= 150) & (x <= 600)
+    result[m3] = 115
+
+    m4 = (~m1) & (x > 600) & (x < 800)
+    result[m4] = (x[m4] - 600) / 200.0 * (ch[m4] - 115) + 115
+
+    #  higher than 800 km, just what's left
+    m5 = ~(m1 | m2 | m3 | m4)
+    result[m5] = ch[m5]
+
+    # If it was a single range, convert it back
+    return result.item() if is_scalar else result
+
 
 
 class VHModels(enum.Enum):

--- a/pydarn/utils/virtual_heights.py
+++ b/pydarn/utils/virtual_heights.py
@@ -20,7 +20,7 @@
 import enum
 import numpy as np
 
-def chisham(target_range: float, **kwargs):
+def chisham(target_range: float | np.typing.NDArray, **kwargs):
     """
     Mapping ionospheric backscatter measured by the SuperDARN HF
     radars – Part 1: A new empirical virtual height model by
@@ -65,7 +65,7 @@ def chisham(target_range: float, **kwargs):
     return result.item() if is_scalar else result
 
 
-def standard_virtual_height(target_range: float, cell_height: int = 300,
+def standard_virtual_height(target_range: float | np.typing.NDArray, cell_height: int = 300,
                             **kwargs):
     """
     cell_height, target_range and x_height are in km


### PR DESCRIPTION
# Scope 

This PR vectorises the `gate2geographic_location()` function, and all relevant child functions (including geocentric conversion and virtual height model functions) to enable calculations of multiple beam/range combos at once. I wanted this for a project I'm working on because I end up iterating over a lot of different range gates. This provides a big speed up that scales the more beams/gates you need. This touches a fair few different spots, mostly just to ensure it handles both numpy arrays OR single scalars. This means it should not affect any upstream code that also uses these functions.

Currently, this makes the assumption that all the beams/gates come from the same radar and record (constant `stid`, `rsep`, and `frang`). It could be updated to handle that down the line, but that would be a lot more work.

## Approval

**Number of approvals:** 2

## Test

```python
import pydarn
import numpy as np
from pydarn.utils.coordinates import gate2geographic_location

fitacf_file = '/Volumes/The Box/FBI/test/fitacfs/2025/01/20250131.2000.00.inv.a.fitacf'
fitacf_data, _ = pydarn.read_fitacf(fitacf_file)

# Station ID
stid = fitacf_data[0]['stid']
stid_enum = pydarn.RadarID(stid)

# Other required info
rsep = fitacf_data[0]['rsep']
frang = fitacf_data[0]['frang']

# Get coordinates of a single beam/gate - reproduces existing functionaility
lat_single, lon_single = gate2geographic_location(
    stid=stid_enum, beam=7, range_gate=62,
    height=300, center=True, rsep=rsep, frang=frang,
    virtual_height_model=pydarn.VHModels.CHISHAM
)

print(lat_single)
print(lon_single)

# Get coordinates of multiple beams/gates at once
beams = np.array([14, 2, 7])
ranges = np.array([12, 54, 62])
lat_multiple, lon_multiple = gate2geographic_location(
    stid=stid_enum, beam=beams, range_gate=ranges,
    center=True, rsep=rsep, frang=frang,
    virtual_height_model=pydarn.VHModels.CHISHAM
)

print(lat_multiple)
print(lon_multiple)
```
Output:
```
79.0786759977364
-44.99405343894708
[71.52700326 86.07959106 79.078676  ]
[-118.79550748  -59.52516538  -44.99405344]
```

To show this produces the exact same results as before, you can run this test code on the develop branch (for the single beam/gate only):
```python
import pydarn
import numpy as np
from pydarn.utils.coordinates import gate2geographic_location

fitacf_file = '/Volumes/The Box/FBI/test/fitacfs/2025/01/20250131.2000.00.inv.a.fitacf'
fitacf_data, _ = pydarn.read_fitacf(fitacf_file)

# Station ID
stid = fitacf_data[0]['stid']
stid_enum = pydarn.RadarID(stid)

# Other required info
rsep = fitacf_data[0]['rsep']
frang = fitacf_data[0]['frang']

# Get coordinates of a single beam/gate
lat_single, lon_single = gate2geographic_location(
    stid=stid_enum, beam=7, range_gate=62,
    height=300, center=True, rsep=rsep, frang=frang,
    virtual_height_model=pydarn.VHModels.CHISHAM
)

print(lat_single)
print(lon_single)
```
Output:
```
79.0786759977364
-44.99405343894708
```


